### PR TITLE
Same variable name for NIP-07 signer example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ NDK can now ask for permission, via their NIP-07 extension, to...
 **Read the user's public key**
 
 ```ts
-signer.user().then(async (user) => {
+nip07signer.user().then(async (user) => {
     if (!!user.npub) {
-        console.log("Permission granted to read their public key.");
+        console.log("Permission granted to read their public key:", user.npub);
     }
 });
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,9 +108,9 @@ NDK can now ask for permission, via their NIP-07 extension, to...
 **Read the user's public key**
 
 ```ts
-signer.user().then(async (user) => {
+nip07signer.user().then(async (user) => {
     if (!!user.npub) {
-        console.log("Permission granted to read their public key.");
+        console.log("Permission granted to read their public key:", user.npub);
     }
 });
 ```


### PR DESCRIPTION
Make it clear to users that they need the same NIP-07 signer variable (nip07signer), from the previous example code above, to use the .user() function. Also added the user.npub to the console.log message for improved insight.