### PR TITLE
fix: don't use lookbehind in RegEx

### DIFF
--- a/src/events/content-tagger.ts
+++ b/src/events/content-tagger.ts
@@ -10,7 +10,7 @@ export function generateContentTags(
 
     content = content.replace(tagRegex, (tag) => {
         try {
-            const entity = tag.split(/(?<=@|nostr:)/)[1];
+            const entity = tag.split(/(@|nostr:)/)[2];
             const { type, data } = nip19.decode(entity);
             let t: NDKTag;
 


### PR DESCRIPTION
Some versions of Safari don't support it 🤡 is causing Habla to crash in those browsers.