### PR TITLE
Compilation and test fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 **/.vscode
 justfile
 pnpm-lock.yaml
-**/*.js
 **/*.d.ts
 **/*.d.ts.map
 *.tgz

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  }
+};

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     },
     "dependencies": {
         "@noble/secp256k1": "^2.0.0",
+        "@noble/hashes": "^1.3.1",
         "@scure/base": "^1.1.1",
         "@typescript-eslint/eslint-plugin": "^5.57.0",
         "@typescript-eslint/parser": "^5.57.0",


### PR DESCRIPTION
 - Add missing `@noble/hashes` dependency (made `pnpm compile` fail)
 - Add jest config to allow js imports in tests (made `pnpm test` fail)
 - Fix `.gitignore`