### PR TITLE
Nested events

### DIFF
--- a/src/events/nip10.test.ts
+++ b/src/events/nip10.test.ts
@@ -1,0 +1,167 @@
+import NDK, { NDKEvent, nest } from "..";
+
+describe("NDKNestedEvent", () => {
+  const ndk = new NDK();
+
+  describe("nest", () => {
+    it('nests events from marked tags', async () => {
+      const events = rawEvents.map(e => new NDKEvent(ndk, e));
+      const nestedEvents = nest(events);
+      expect(nestedEvents[0].content).toEqual("a");
+      expect(nestedEvents[0].children[0].content).toEqual("b");
+      expect(nestedEvents[0].children[0].children[0].content).toEqual("c");
+    });
+
+    it('nests events from positional tags', async () => {
+      const events = gigiEvents.map(e => new NDKEvent(ndk, e));
+      const nestedEvents = nest(events);
+      expect(nestedEvents[1].children[0].content).toMatch("Unfortunately");
+      expect(nestedEvents[1].children[0].children[0].content).toEqual("we early ");
+    });
+  });
+});
+
+// Test events with NIP-10 marked tags
+const rawEvents = [
+  {
+    "created_at": 0,
+    "pubkey": "a1b2b3",
+    "id": "abc123",
+    "content": "a",
+    "tags": [["p", "123456"]]
+  },
+  {
+    "created_at": 1,
+    "pubkey": "e4d3b2",
+    "id": "456def",
+    "content": "b",
+    "tags": [
+      ["p", "123456"],
+      ["e", "abc123", "", "root"],
+      ["e", "f1e2d3", "", "mention"]
+    ]
+  },
+  {
+    "created_at": 2,
+    "id": "789cef",
+    "pubkey": "f6a9c5",
+    "content": "c",
+    "tags": [
+      ["e", "456def", "", "reply"],
+      ["p", "123456"],
+      ["e", "abc123", "", "root"]
+    ]
+  },
+];
+
+// Real events from naddr1qqxnzd3cxqmrzv3exgmr2wfeqgsxu35yyt0mwjjh8pcz4zprhxegz69t4wr9t74vk6zne58wzh0waycrqsqqqa28pjfdhz
+const gigiEvents = [
+  {
+    "created_at": 1684674845,
+    "content": "Getting my head around this",
+    "tags": [
+      [
+        "p",
+        "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52"
+      ],
+      [
+        "e",
+        "532808e4d60f5f82b95aeaa3ed2e930a0c5973dccb0ede68b28b1931db91440f"
+      ],
+      [
+        "p",
+        "6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93"
+      ],
+      [
+        "a",
+        "30023:6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93:1680612926599"
+      ]
+    ],
+    "kind": 1,
+    "pubkey": "d85c99afd244911e0aaf800cbea4221df557f06f8a4ff2cbe84b24e0b9e728fc",
+    "id": "741f5367a9415f4d6f19c0f57a1e4647c8ed8309b53b0da2d82fc4ebfba03b2c",
+    "sig": "069874040bac26a219777fc0f90b8f4df71e38c30e3e6a953d53222499d8e0c5a8f32c6b4204d14eb335bb654f01c5610372d9dc00062284b8e0f2bb98c7ed85"
+  },
+  {
+    "created_at": 1680636068,
+    "content": "we early ",
+    "tags": [
+      [
+        "e",
+        "44d3ecbb5752e96becc330d9b56352ea595d37b4c55edd8701fd24f18df5eee2",
+      ],
+      [
+        "e",
+        "d4a0b4f08d98d82a04292654ec132723cc2cf3fa24ffb6c0833426cb9372f4d5",
+      ],
+      [
+        "p",
+        "6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93"
+      ],
+      [
+        "p",
+        "39a8b17475be0db44e313f9fd032ffde183c8abd6498e4932a873330d2cd4868"
+      ],
+      [
+        "a",
+        "30023:6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93:1680612926599"
+      ]
+    ],
+    "kind": 1,
+    "pubkey": "6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93",
+    "id": "8cdc4676aca93bbafcfbe6784f9b2df54e8ca20fbe69ba55fda487736bfdb7f6",
+    "sig": "b8026e43c61b491014915caf79289968b87e52aa87a487ebecbf6cb2b3c07d460f2ab1a86da99b1c5410a0f5d14e77cf27f78c56bf1ab709f0d616ad2711de78"
+  },
+  {
+    "created_at": 1680618462,
+    "content": "Unfortunately when boosting this it gets broken 🥹\n#[1]",
+    "tags": [
+      [
+        "e",
+        "44d3ecbb5752e96becc330d9b56352ea595d37b4c55edd8701fd24f18df5eee2"
+      ],
+      [
+        "p",
+        "6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93"
+      ],
+      [
+        "p",
+        "39a8b17475be0db44e313f9fd032ffde183c8abd6498e4932a873330d2cd4868"
+      ],
+      [
+        "a",
+        "30023:6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93:1680612926599"
+      ]
+    ],
+    "kind": 1,
+    "pubkey": "39a8b17475be0db44e313f9fd032ffde183c8abd6498e4932a873330d2cd4868",
+    "id": "d4a0b4f08d98d82a04292654ec132723cc2cf3fa24ffb6c0833426cb9372f4d5",
+    "sig": "c4a4197df4fec008f2f565170d09c46f0b9a7217ed90432cb53d1dddf70ad8520722b6e4f04ec9e52dd219ee01387c6191f449cd10a6c2488b1d2866424b7a8a"
+  },
+  {
+    "created_at": 1680618199,
+    "content": "Another #[1] \"must read\" #Bitcoin #Nostr 🤯\n\n\"Imagine a visual overlay of all public highlights, automatically shining a light on what the swarm of readers found most useful, insightful, funny, etc.\n\nFurther, imagine the possibility of sharing these highlights ... with one click, automatically tagging the highlighter(s) as well as the author, of course, so that eventual sat-flows can be split and forwarded automatically.\"\n\n#[0]",
+    "tags": [
+      [
+        "p",
+        "6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93"
+      ],
+      [
+        "a",
+        "30023:6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93:1680612926599"
+      ],
+      [
+        "t",
+        "Bitcoin"
+      ],
+      [
+        "t",
+        "Nostr"
+      ]
+    ],
+    "kind": 1,
+    "pubkey": "39a8b17475be0db44e313f9fd032ffde183c8abd6498e4932a873330d2cd4868",
+    "id": "44d3ecbb5752e96becc330d9b56352ea595d37b4c55edd8701fd24f18df5eee2",
+    "sig": "19d438f753f88bf5f1dd2d01977a196d5b954d740fdd98c4546a8a7179972d9bca2864366af6025a5bea3e0a41fc30bfc0a162e66760ea6727bba8c5ca4a0de2"
+  },
+];

--- a/src/events/nip10.ts
+++ b/src/events/nip10.ts
@@ -1,0 +1,60 @@
+import { nip10 } from "nostr-tools";
+import NDKEvent from ".";
+
+/**
+ * NDKNestedEvent is a subclass of NDKEvent that contains
+ * references to root and reply NDKEvents, and a children
+ * getter for accessing nested events. See `nest`.
+ */
+export class NDKNestedEvent extends NDKEvent {
+  readonly root?: NDKEvent;
+  readonly reply?: NDKEvent;
+  readonly children: NDKNestedEvent[] = [];
+
+  constructor(event: NDKEvent,
+    root?: NDKEvent | undefined,
+    reply?: NDKEvent | undefined,
+    mentions: NDKEvent[] = []) {
+    super(event.ndk, event.rawEvent());
+    this.root = root ? new NDKNestedEvent(root) : undefined;
+    this.reply = reply ? new NDKNestedEvent(reply) : undefined;
+  }
+}
+
+/**
+ * Returns a nested array of NDKNestedEvent by using the "e"
+ * tags in the input array.
+ * 
+ * Typically used to show threaded events in UIs.
+ *
+ * @param events a flat array of NDKEvent
+ * @returns an array of nested NDKNestedEvent
+ */
+export function nest(events: NDKEvent[]): NDKNestedEvent[] {
+  const nestedEvents = events.map(e => {
+    const nip10Result = nip10.parse(e);
+    const root = events.find(e => e.id === nip10Result.root?.id);
+    const reply = events.find(e => e.id === nip10Result.reply?.id);
+    return new NDKNestedEvent(e, root, reply);
+  });
+  return unflatten(nestedEvents);
+}
+
+function unflatten(events: NDKNestedEvent[], parent?: string | undefined): NDKNestedEvent[] {
+  // Find all events at this level of recursion (filter by parent)
+  // NIP-10: For top level replies only the "root" marker should be used
+  const result = new Set(events.filter(e => {
+    return (e.reply?.id || e.root?.id) === parent;
+  }));
+
+  // Remove found events from the original event array
+  events = events.filter(e => !result.has(e));
+
+  // For every event at this level, apply the same logic and add to children
+  for (let e of result) {
+    e.children.push(...unflatten(events, e.id));
+  }
+
+  // Return an array of nested events
+  return [...result];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { NDKUserProfile } from "./user/profile.js";
 
 export * from "./events/index.js";
 export { NDKKind } from "./events/kind.js";
+export * from "./events/nip10.js";
 export * from "./relay/index.js";
 export * from "./relay/sets/index.js";
 export * from "./signers/index.js";


### PR DESCRIPTION
Added a `nest` function that turns a flat array of events with `e` tags into a nested array of events (`NDKNestedEvent` which has pointers to `root`, `reply` and a convenience array of `children`).

Useful for displaying threaded conversations.

Let me know if anything needs rework.