### PR TITLE
Add Marketplace Kinds

### DIFF
--- a/src/events/kinds/index.ts
+++ b/src/events/kinds/index.ts
@@ -27,6 +27,8 @@ export enum NDKKind {
     CategorizedRelayList = 30022,
     ProfileBadge = 30008,
     BadgeDefinition = 30009,
+    MarketStall = 30017,
+    MarketProduct = 30018,
     Article = 30023,
     AppSpecificData = 30078
 }


### PR DESCRIPTION
Most nostr libraries (as far as I've seen) leave out the Nip-15 event kinds.