### PR TITLE
Add zap convenience method to users

### DIFF
--- a/ndk/src/events/index.ts
+++ b/ndk/src/events/index.ts
@@ -375,6 +375,7 @@ export class NDKEvent extends EventEmitter {
      * @param amount The amount to zap in millisatoshis
      * @param comment A comment to add to the zap request
      * @param extraTags Extra tags to add to the zap request
+     * @param recipient The zap recipient (optional for events)
      */
     async zap(
         amount: number,
@@ -393,8 +394,6 @@ export class NDKEvent extends EventEmitter {
         });
 
         const paymentRequest = await zap.createZapRequest(amount, comment, extraTags);
-
-        // await zap.publish(amount);
         return paymentRequest;
     }
 

--- a/ndk/src/user/index.ts
+++ b/ndk/src/user/index.ts
@@ -10,6 +10,7 @@ import { NDKRelaySet } from "../relay/sets/index.js";
 import { NDKSubscriptionCacheUsage, type NDKSubscriptionOptions } from "../subscription/index.js";
 import { follows } from "./follows.js";
 import { type NDKUserProfile, profileFromEvent, serializeProfile } from "./profile.js";
+import Zap from "../zap/index.js";
 
 export type Hexpubkey = string;
 
@@ -225,7 +226,9 @@ export class NDKUser {
                 relayList.writeRelayUrls = Array.from(writeRelays);
 
                 return relayList;
-            } catch (e) {}
+            } catch (e) {
+                // Don't do anything
+            }
         }
 
         return undefined;
@@ -306,5 +309,26 @@ export class NDKUser {
 
         if (profilePointer === null) return null;
         return profilePointer.pubkey === this.hexpubkey;
+    }
+
+    /**
+     * Zap a user
+     *
+     * @param amount The amount to zap in millisatoshis
+     * @param comment A comment to add to the zap request
+     * @param extraTags Extra tags to add to the zap request
+     */
+    async zap(amount: number, comment?: string, extraTags?: NDKTag[]): Promise<string | null> {
+        if (!this.ndk) throw new Error("No NDK instance found");
+
+        this.ndk.assertSigner();
+
+        const zap = new Zap({
+            ndk: this.ndk,
+            zappedUser: this,
+        });
+
+        const paymentRequest = await zap.createZapRequest(amount, comment, extraTags);
+        return paymentRequest;
     }
 }

--- a/ndk/src/zap/index.ts
+++ b/ndk/src/zap/index.ts
@@ -22,22 +22,18 @@ interface ZapConstructorParams {
     zappedUser?: NDKUser;
 }
 
-type ZapConstructorParamsRequired = Required<Pick<ZapConstructorParams, "zappedEvent">> &
-    Pick<ZapConstructorParams, "zappedUser"> &
-    ZapConstructorParams;
-
 export default class Zap extends EventEmitter {
     public ndk?: NDK;
     public zappedEvent?: NDKEvent;
     public zappedUser: NDKUser;
 
-    public constructor(args: ZapConstructorParamsRequired) {
+    public constructor(args: ZapConstructorParams) {
         super();
         this.ndk = args.ndk;
         this.zappedEvent = args.zappedEvent;
 
         this.zappedUser =
-            args.zappedUser || this.ndk.getUser({ hexpubkey: this.zappedEvent.pubkey });
+            args.zappedUser || this.ndk.getUser({ hexpubkey: this.zappedEvent?.pubkey });
     }
 
     public async getZapEndpoint(): Promise<string | undefined> {


### PR DESCRIPTION
Seems odd that this isn't already in NDK so I'm not 100% sure I'm understanding this correctly.

In any case, this appears to be all that's needed to add a simple `User.zap` convenience method.