### PR TITLE
Static references for replaceable events

### DIFF
--- a/ndk/src/events/index.test.ts
+++ b/ndk/src/events/index.test.ts
@@ -168,7 +168,7 @@ describe("NDKEvent", () => {
         });
     });
 
-    describe("tagReference", () => {
+    describe("referenceTags", () => {
         it("returns the correct tag for referencing the event", () => {
             const event1 = new NDKEvent(ndk, {
                 created_at: Date.now() / 1000,
@@ -176,6 +176,7 @@ describe("NDKEvent", () => {
                 kind: 30000,
                 pubkey: "pubkey",
                 tags: [["d", "d-code"]],
+                id: "eventid1",
             });
 
             const event2 = new NDKEvent(ndk, {
@@ -184,11 +185,14 @@ describe("NDKEvent", () => {
                 tags: [],
                 kind: 1,
                 pubkey: "pubkey",
-                id: "eventid",
+                id: "eventid2",
             });
 
-            expect(event1.tagReference()).toEqual(["a", "30000:pubkey:d-code"]);
-            expect(event2.tagReference()).toEqual(["e", "eventid"]);
+            expect(event1.referenceTags()).toEqual([
+                ["a", "30000:pubkey:d-code"],
+                ["e", "eventid1"],
+            ]);
+            expect(event2.referenceTags()).toEqual([["e", "eventid2"]]);
         });
     });
 

--- a/ndk/src/events/index.ts
+++ b/ndk/src/events/index.ts
@@ -113,9 +113,9 @@ export class NDKEvent extends EventEmitter {
      */
     public tag(event: NDKEvent, marker?: string): void;
     public tag(userOrEvent: NDKUser | NDKEvent, marker?: string): void {
-        const tag = userOrEvent.tagReference();
-        if (marker) tag.push(marker);
-        this.tags.push(tag);
+        const tags = userOrEvent.referenceTags();
+        if (marker) tags[0].push(marker);
+        this.tags.push(...tags);
 
         if (userOrEvent instanceof NDKEvent) {
             const tagEventAuthor = userOrEvent.author;
@@ -322,15 +322,26 @@ export class NDKEvent extends EventEmitter {
      */
     tagId(): string {
         // NIP-33
-        if (this.kind && this.kind >= 30000 && this.kind <= 40000) {
-            const dTagId = this.replaceableDTag();
-
-            return `${this.kind}:${this.pubkey}:${dTagId}`;
+        if (this.isParamReplaceable()) {
+            return this.tagAddress();
         }
 
         return this.id;
     }
 
+    /**
+     * Returns the "reference" value ("<kind>:<author-pubkey>:<d-tag>") for this replaceable event.
+     * @returns {string} The id
+     */
+    tagAddress(): string {
+        if (!this.isParamReplaceable()) {
+            throw new Error("This must only be called on replaceable events");
+        }
+        const dTagId = this.replaceableDTag();
+        return `${this.kind}:${this.pubkey}:${dTagId}`;
+    }
+
+    /** @deprecated Use referenceTags instead. */
     /**
      * Get the tag that can be used to reference this event from another event
      * @example
@@ -344,10 +355,32 @@ export class NDKEvent extends EventEmitter {
     tagReference(): NDKTag {
         // NIP-33
         if (this.isParamReplaceable()) {
-            return ["a", this.tagId()];
+            return ["a", this.tagAddress()];
         }
 
         return ["e", this.tagId()];
+    }
+
+    /**
+     * Get the tags that can be used to reference this event from another event
+     * @example
+     *     event = new NDKEvent(ndk, { kind: 30000, pubkey: 'pubkey', tags: [ ["d", "d-code"] ] });
+     *     event.referenceTags(); // [["a", "30000:pubkey:d-code"], ["e", "parent-id"]]
+     *
+     *     event = new NDKEvent(ndk, { kind: 1, pubkey: 'pubkey', id: "eventid" });
+     *     event.referenceTags(); // [["e", "parent-id"]]
+     * @returns {NDKTag} The NDKTag object referencing this event
+     */
+    referenceTags(): NDKTag[] {
+        // NIP-33
+        if (this.isParamReplaceable()) {
+            return [
+                ["a", this.tagAddress()],
+                ["e", this.id],
+            ];
+        }
+
+        return [["e", this.id]];
     }
 
     /**

--- a/ndk/src/events/kinds/lists/index.ts
+++ b/ndk/src/events/kinds/lists/index.ts
@@ -201,35 +201,35 @@ export class NDKList extends NDKEvent {
         if (!this.ndk) throw new Error("NDK instance not set");
         if (!this.ndk.signer) throw new Error("NDK signer not set");
 
-        let tag;
+        let tags: NDKTag[];
 
         if (item instanceof NDKEvent) {
-            tag = item.tagReference();
+            tags = item.referenceTags();
         } else if (item instanceof NDKUser) {
-            tag = item.tagReference();
+            tags = item.referenceTags();
         } else if (item instanceof NDKRelay) {
-            tag = item.tagReference();
+            tags = item.referenceTags();
         } else if (Array.isArray(item)) {
             // NDKTag
-            tag = item;
+            tags = [item];
         } else {
             throw new Error("Invalid object type");
         }
 
-        if (mark) tag.push(mark);
+        if (mark) tags[0].push(mark);
 
         if (encrypted) {
             const user = await this.ndk.signer.user();
             const currentList = await this.encryptedTags();
 
-            currentList.push(tag);
+            currentList.push(...tags);
 
             this._encryptedTags = currentList;
             this.encryptedTagsLength = this.content.length;
             this.content = JSON.stringify(currentList);
             await this.encrypt(user);
         } else {
-            this.tags.push(tag);
+            this.tags.push(...tags);
         }
 
         this.created_at = Math.floor(Date.now() / 1000);

--- a/ndk/src/relay/index.ts
+++ b/ndk/src/relay/index.ts
@@ -130,6 +130,7 @@ export class NDKRelay extends EventEmitter {
         // TODO
     }
 
+    /** @deprecated Use referenceTags instead. */
     public tagReference(marker?: string): NDKTag {
         const tag = ["r", this.url];
 
@@ -138,6 +139,10 @@ export class NDKRelay extends EventEmitter {
         }
 
         return tag;
+    }
+
+    public referenceTags(): NDKTag[] {
+        return [["r", this.url]];
     }
 
     public activeSubscriptions(): Map<NDKFilter[], NDKSubscription[]> {

--- a/ndk/src/user/index.ts
+++ b/ndk/src/user/index.ts
@@ -231,12 +231,21 @@ export class NDKUser {
         return undefined;
     }
 
+    /** @deprecated Use referenceTags instead. */
     /**
      * Get the tag that can be used to reference this user in an event
      * @returns {NDKTag} an NDKTag
      */
     public tagReference(): NDKTag {
         return ["p", this.hexpubkey];
+    }
+
+    /**
+     * Get the tags that can be used to reference this user in an event
+     * @returns {NDKTag[]} an array of NDKTag
+     */
+    public referenceTags(): NDKTag[] {
+        return [["p", this.hexpubkey]];
     }
 
     /**

--- a/ndk/src/zap/index.ts
+++ b/ndk/src/zap/index.ts
@@ -114,10 +114,8 @@ export default class Zap extends EventEmitter {
 
         // add the event tag if it exists; this supports both 'e' and 'a' tags
         if (this.zappedEvent) {
-            const tag = this.zappedEvent.tagReference();
-            if (tag) {
-                zapRequest.tags.push(tag);
-            }
+            const tags = this.zappedEvent.referenceTags();
+            zapRequest.tags.push(...tags);
         }
 
         zapRequest.tags.push(["lnurl", zapEndpoint]);


### PR DESCRIPTION
Replace `.tagReference()` with `.referenceTags()` that include an "e" tag for replaceable events.

This prevents people from rugging the original article someone had replied to and changing the meaning of replies, zaps etc.