### PR TITLE
React to event

### DIFF
--- a/ndk/src/events/index.ts
+++ b/ndk/src/events/index.ts
@@ -225,7 +225,7 @@ export class NDKEvent extends EventEmitter {
             this.author = await signer.user();
         }
 
-        await this.generateTags();
+        this.generateTags();
 
         if (this.isReplaceable()) {
             this.created_at = Math.floor(Date.now() / 1000);
@@ -487,4 +487,24 @@ export class NDKEvent extends EventEmitter {
      * @function
      */
     public repost = repost.bind(this);
+
+    /**
+     * React to an existing event
+     *
+     * @param content The content of the reaction
+     */
+    async react(content: string): Promise<NDKEvent> {
+        if (!this.ndk) throw new Error("No NDK instance found");
+
+        this.ndk.assertSigner();
+
+        const e = new NDKEvent(this.ndk, {
+            kind: NDKKind.Reaction,
+            content,
+        } as NostrEvent);
+        e.tag(this);
+        await e.publish();
+
+        return e;
+    }
 }

--- a/ndk/src/ndk/index.ts
+++ b/ndk/src/ndk/index.ts
@@ -442,7 +442,7 @@ export class NDK extends EventEmitter {
     /**
      * Ensures that a signer is available to sign an event.
      */
-    public async assertSigner() {
+    public assertSigner() {
         if (!this.signer) {
             this.emit("signerRequired");
             throw new Error("Signer required");

--- a/ndk/src/signers/nip07/index.ts
+++ b/ndk/src/signers/nip07/index.ts
@@ -160,7 +160,7 @@ export class NDKNip07Signer implements NDKSigner {
                 return;
             }
 
-            let timerId: NodeJS.Timeout;
+            let timerId: NodeJS.Timeout | number;
 
             // Create an interval to repeatedly check for window.nostr
             const intervalId = setInterval(() => {

--- a/ndk/src/subscription/index.ts
+++ b/ndk/src/subscription/index.ts
@@ -330,6 +330,8 @@ export class NDKSubscription extends EventEmitter {
             this.eventFirstSeen.set(event.id, 0);
         }
 
+        if (!event.ndk) event.ndk = this.ndk;
+
         this.emit("event", event, relay, this);
         this.lastEventReceivedAt = Date.now();
     }


### PR DESCRIPTION
## changes (separated by different commits):

### 1) fixed a failing test:
![image](https://github.com/nostr-dev-kit/ndk/assets/25853688/643a5716-1e61-4bfa-a9e1-ee2c53b796f1)

### 2) added ndk instance to events those which are received from a `ndk.subscribe`
- [x] now `event.ndk` is available for events when using `ndk.subscribe`
- [x] now methods (those which are dependent to ndk instance) can be executed directly from an event. e.g. `event.zap()`

### 3) removed a tiny unnecessary `async` prefix.

### 4) added `react` method to events.
- [x] now we can use `event.react('+')`
- [x] fixed this issue: https://github.com/nostr-dev-kit/ndk/issues/93