### PR TITLE
Add Support for NIP-07 getRelays()

### DIFF
--- a/ndk/README.md
+++ b/ndk/README.md
@@ -93,10 +93,21 @@ You can pass an object with several options to a newly created instance of NDK.
 // Import the package
 import NDK from "@nostr-dev-kit/ndk";
 
-/ Create a new NDK instance with explicit relays
+// Create a new NDK instance with explicit relays
 const ndk = new NDK({
     explicitRelayUrls: ["wss://a.relay", "wss://another.relay"],
 });
+```
+
+If the signer implements the `getRelays()` method, NDK will use the relays returned by that method as the explicit relays.
+
+```ts
+// Import the package
+import NDK, { NDKNip07Signer } from "@nostr-dev-kit/ndk";
+
+// Create a new NDK instance with just a signer (provided the signer implements the getRelays() method)
+const nip07signer = new NDKNip07Signer();
+const ndk = new NDK({ signer: nip07signer });
 ```
 
 Note: In normal client use, it's best practice to instantiate NDK as a singleton class. [See more below](#architecture-decisions--suggestions).

--- a/ndk/src/ndk/index.ts
+++ b/ndk/src/ndk/index.ts
@@ -254,6 +254,13 @@ export class NDK extends EventEmitter {
      * If the timeout is reached, the connection will be continued to be established in the background.
      */
     public async connect(timeoutMs?: number): Promise<void> {
+        if (this._signer && this.autoConnectUserRelays) {
+            this.debug("Attempting to connect to user relays specified by signer");
+            
+            const relays = await this._signer.relays();
+            relays.forEach(relay => this.pool.addRelay(relay));
+        }
+
         const connections = [this.pool.connect(timeoutMs)];
 
         if (this.outboxPool) {

--- a/ndk/src/signers/index.ts
+++ b/ndk/src/signers/index.ts
@@ -1,4 +1,5 @@
 import type { NostrEvent } from "../events/index.js";
+import { NDKRelay } from "../relay/index.js";
 import type { NDKUser } from "../user";
 
 /**
@@ -23,6 +24,12 @@ export interface NDKSigner {
      * @returns A promise that resolves to the signature of the signed event.
      */
     sign(event: NostrEvent): Promise<string>;
+
+    /**
+     * Getter for the preferred relays.
+     * @returns A promise containing a simple map of preferred relays and their read/write policies.
+     */
+    relays(): Promise<NDKRelay[]>;
 
     /**
      * Encrypts the given Nostr event for the given recipient.

--- a/ndk/src/signers/nip07/index.ts
+++ b/ndk/src/signers/nip07/index.ts
@@ -192,8 +192,8 @@ declare global {
         nostr?: {
             getPublicKey(): Promise<string>;
             signEvent(event: NostrEvent): Promise<{ sig: string }>;
-            getRelays(): Promise<Nip07RelayMap>;
-            nip04: {
+            getRelays?: () => Promise<Nip07RelayMap>;
+            nip04?: {
                 encrypt(recipientHexPubKey: string, value: string): Promise<string>;
                 decrypt(senderHexPubKey: string, value: string): Promise<string>;
             };

--- a/ndk/src/signers/nip07/index.ts
+++ b/ndk/src/signers/nip07/index.ts
@@ -12,6 +12,13 @@ type Nip04QueueItem = {
     reject: (reason?: Error) => void;
 };
 
+type Nip07RelayMap = {
+    [key: string]: {
+        read: boolean;
+        write: boolean;
+    };
+};
+
 /**
  * NDKNip07Signer implements the NDKSigner interface for signing Nostr events
  * with a NIP-07 browser extension (e.g., getalby, nos2x).
@@ -185,6 +192,7 @@ declare global {
         nostr?: {
             getPublicKey(): Promise<string>;
             signEvent(event: NostrEvent): Promise<{ sig: string }>;
+            getRelays(): Promise<Nip07RelayMap>;
             nip04: {
                 encrypt(recipientHexPubKey: string, value: string): Promise<string>;
                 decrypt(senderHexPubKey: string, value: string): Promise<string>;


### PR DESCRIPTION
[NIP-07](https://github.com/nostr-protocol/nips/blob/master/07.md) defines an optional `getRelays()` method, but I noticed it is not currently supported in NDK.

This PR sets up NDK to attempt to connect to the signer-provided relay list when possible.