### PR TITLE
fix event author unexpected reset

### DIFF
--- a/ndk/src/events/index.ts
+++ b/ndk/src/events/index.ts
@@ -44,6 +44,8 @@ export class NDKEvent extends EventEmitter {
     public sig?: string;
     public pubkey = "";
 
+    private _author: NDKUser | undefined = undefined;
+
     /**
      * The relay that this event was first received from.
      */
@@ -78,14 +80,20 @@ export class NDKEvent extends EventEmitter {
 
     set author(user: NDKUser) {
         this.pubkey = user.hexpubkey;
+
+        this._author = undefined;
     }
 
     /**
      * Returns an NDKUser for the author of the event.
      */
     get author(): NDKUser {
+        if (this._author) return this._author;
+        
         if (!this.ndk) throw new Error("No NDK instance found");
+        
         const user = this.ndk.getUser({ hexpubkey: this.pubkey });
+        this._author = user;
         return user;
     }
 


### PR DESCRIPTION
calling `ndk.getUser` will always return a new instance of `NDKUser` which will cause a reset in author object every time we call `event.author`. this behavior is not expected!
for example after calling `event.author.fetchProfile()` we expect that the `event.author` object is now containing the `profile` object, but we are still getting `undefined` though we've already fetched the `profile`!
so I've added a private `_author` property inside each event instance, which is responsible for holding the actual value of `author`.
now we don't get a newly created partial NDKUser every time we call `event.author`.