### PR TITLE
Make NDK faster than anything else

### DIFF
--- a/ndk/package.json
+++ b/ndk/package.json
@@ -60,10 +60,10 @@
         "@noble/secp256k1": "^2.0.0",
         "@scure/base": "^1.1.1",
         "debug": "^4.3.4",
-        "eventemitter3": "^5.0.1",
         "light-bolt11-decoder": "^3.0.0",
         "node-fetch": "^3.3.1",
         "nostr-tools": "^1.15.0",
+        "tseep": "^1.1.1",
         "typescript-lru-cache": "^2.0.0",
         "utf8-buffer": "^1.0.0",
         "websocket-polyfill": "^0.0.3"

--- a/ndk/src/events/index.ts
+++ b/ndk/src/events/index.ts
@@ -1,4 +1,4 @@
-import EventEmitter from "eventemitter3";
+import { EventEmitter } from "tseep";
 import type { UnsignedEvent } from "nostr-tools";
 import { getEventHash } from "nostr-tools";
 

--- a/ndk/src/ndk/index.ts
+++ b/ndk/src/ndk/index.ts
@@ -1,5 +1,5 @@
 import debug from "debug";
-import EventEmitter from "eventemitter3";
+import { EventEmitter } from "tseep";
 
 import type { NDKCacheAdapter } from "../cache/index.js";
 import dedupEvent from "../events/dedup.js";

--- a/ndk/src/outbox/tracker.ts
+++ b/ndk/src/outbox/tracker.ts
@@ -1,4 +1,4 @@
-import EventEmitter from "eventemitter3";
+import { EventEmitter } from "tseep";
 import { LRUCache } from "typescript-lru-cache";
 
 import type { NDKRelayList } from "../events/kinds/NDKRelayList.js";

--- a/ndk/src/relay/index.ts
+++ b/ndk/src/relay/index.ts
@@ -1,5 +1,5 @@
 import debug from "debug";
-import EventEmitter from "eventemitter3";
+import { EventEmitter } from "tseep";
 
 import type { NDKEvent, NDKTag } from "../events/index.js";
 import type { NDKFilter, NDKSubscription } from "../subscription/index.js";

--- a/ndk/src/relay/pool/index.test.ts
+++ b/ndk/src/relay/pool/index.test.ts
@@ -1,4 +1,4 @@
-//import "websocket-polyfill";
+import "websocket-polyfill";
 
 import { NDK } from "../../ndk/index.js";
 import { NDKRelay } from "../index.js";

--- a/ndk/src/relay/pool/index.test.ts
+++ b/ndk/src/relay/pool/index.test.ts
@@ -1,4 +1,4 @@
-import "websocket-polyfill";
+//import "websocket-polyfill";
 
 import { NDK } from "../../ndk/index.js";
 import { NDKRelay } from "../index.js";

--- a/ndk/src/relay/pool/index.ts
+++ b/ndk/src/relay/pool/index.ts
@@ -1,5 +1,5 @@
 import type debug from "debug";
-import EventEmitter from "eventemitter3";
+import { EventEmitter } from "tseep";
 
 import type { NDK } from "../../ndk/index.js";
 import type { NDKRelayUrl } from "../index.js";

--- a/ndk/src/relay/pool/index.ts
+++ b/ndk/src/relay/pool/index.ts
@@ -95,9 +95,9 @@ export class NDKPool extends EventEmitter {
             return;
         }
 
-        relay.on("notice", (relay, notice) => this.emit("notice", relay, notice));
+        relay.on("notice", async (relay, notice) => this.emit("notice", relay, notice));
         relay.on("connect", () => this.handleRelayConnect(relayUrl));
-        relay.on("disconnect", () => this.emit("relay:disconnect", relay));
+        relay.on("disconnect", async () => this.emit("relay:disconnect", relay));
         relay.on("flapping", () => this.handleFlapping(relay));
         this.relays.set(relayUrl, relay);
 

--- a/ndk/src/relay/subscriptions.ts
+++ b/ndk/src/relay/subscriptions.ts
@@ -1,4 +1,4 @@
-import EventEmitter from "eventemitter3";
+import { EventEmitter } from "tseep";
 import type { Sub } from "nostr-tools";
 import { matchFilter } from "nostr-tools";
 

--- a/ndk/src/signers/nip46/rpc.ts
+++ b/ndk/src/signers/nip46/rpc.ts
@@ -1,4 +1,4 @@
-import EventEmitter from "eventemitter3";
+import { EventEmitter } from "tseep";
 
 import type { NDKSigner } from "..";
 import type { NostrEvent } from "../../events";

--- a/ndk/src/subscription/index.ts
+++ b/ndk/src/subscription/index.ts
@@ -1,4 +1,4 @@
-import EventEmitter from "eventemitter3";
+import { EventEmitter } from "tseep";
 
 import type { NDKEvent, NDKEventId } from "../events/index.js";
 import type { NDKKind } from "../events/kinds/index.js";

--- a/ndk/src/zap/index.ts
+++ b/ndk/src/zap/index.ts
@@ -1,5 +1,5 @@
 import { bech32 } from "@scure/base";
-import EventEmitter from "eventemitter3";
+import { EventEmitter } from "tseep";
 import { nip57 } from "nostr-tools";
 
 import type { NostrEvent } from "../events/index.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       debug:
         specifier: ^4.3.4
         version: 4.3.4
-      eventemitter3:
-        specifier: ^5.0.1
-        version: 5.0.1
       light-bolt11-decoder:
         specifier: ^3.0.0
         version: 3.0.0
@@ -56,6 +53,9 @@ importers:
       nostr-tools:
         specifier: ^1.15.0
         version: 1.15.0(typescript@5.2.2)
+      tseep:
+        specifier: ^1.1.1
+        version: 1.1.1
       typescript-lru-cache:
         specifier: ^2.0.0
         version: 2.0.0
@@ -7150,10 +7150,6 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
-  /eventemitter3@5.0.1:
-    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
-    dev: false
-
   /execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -12161,6 +12157,10 @@ packages:
       path-exists: 4.0.0
       read-pkg-up: 7.0.1
     dev: true
+
+  /tseep@1.1.1:
+    resolution: {integrity: sha512-w2MjaqNWGDeliT5/W+/lhhnR0URiVwXXsXbkAZjQVywrOpdKhQAOL1ycyHfNOV1QBjouC7FawNmJePet1sGesw==}
+    dev: false
 
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}


### PR DESCRIPTION
`tseep` is faster than `eventemitter3` by 13x, [source](https://github.com/Morglod/tseep/blob/master/benchmarks/results.md)

by replace `eventemitter3` with `tseep`, ndk is faster by 13x without doing anything 😎. I'm also tested it in Lume and it work totally fine, I didn't catch any issues so far