### PR TITLE
fix: cleanup subscription listeners in `stop` function

### DIFF
--- a/ndk/src/subscription/index.ts
+++ b/ndk/src/subscription/index.ts
@@ -244,6 +244,7 @@ export class NDKSubscription extends EventEmitter {
     public stop(): void {
         // this.debug(`running stop ${this.internalId}`);
         this.emit("close", this);
+        this.removeAllListeners();
     }
 
     /**


### PR DESCRIPTION
The `stop()` method of NDKSubscription does not clean up the event listeners of the subscription.

https://github.com/nostr-dev-kit/ndk/blob/f7b4c9972d2645db07e64a0edc127f4306330db9/ndk/src/subscription/index.ts#L244-L247

 This is likely causing a memory leak when calling `fetchEvent()` and `fetchEvents()` which keep a reference to the `s` object.

https://github.com/nostr-dev-kit/ndk/blob/f7b4c9972d2645db07e64a0edc127f4306330db9/ndk/src/ndk/index.ts#L409-L424