### PR TITLE
Limit the scope of clientName tag

### DIFF
--- a/ndk/src/events/index.ts
+++ b/ndk/src/events/index.ts
@@ -284,7 +284,11 @@ export class NDKEvent extends EventEmitter {
             }
         }
 
-        if ((this.ndk?.clientName || this.ndk?.clientNip89) && !this.tagValue("client")) {
+        if (
+            (this.ndk?.clientName || this.ndk?.clientNip89) &&
+            (this.kind === NDKKind.Text || this.kind === NDKKind.Article) &&
+            !this.tagValue("client")
+        ) {
             const clientTag: NDKTag = ["client", this.ndk.clientName ?? ""];
             if (this.ndk.clientNip89) clientTag.push(this.ndk.clientNip89);
             tags.push(clientTag);

--- a/ndk/src/events/index.ts
+++ b/ndk/src/events/index.ts
@@ -289,8 +289,12 @@ export class NDKEvent extends EventEmitter {
             (this.kind === NDKKind.Text || this.kind === NDKKind.Article) &&
             !this.tagValue("client")
         ) {
-            const clientTag: NDKTag = ["client", this.ndk.clientName ?? ""];
-            if (this.ndk.clientNip89) clientTag.push(this.ndk.clientNip89);
+            const clientTag: NDKTag = [
+                "client",
+                this.ndk.clientName ?? "",
+                this.ndk.clientNip89 ?? "",
+                this.relay?.url ?? "",
+            ];
             tags.push(clientTag);
         }
 

--- a/ndk/src/ndk/index.ts
+++ b/ndk/src/ndk/index.ts
@@ -85,6 +85,7 @@ export interface NDKConstructorParams {
 
     /**
      * Client nip89 to add to events' tag
+     * @example "31990:app1-pubkey:<d-identifier>"
      */
     clientNip89?: string;
 }


### PR DESCRIPTION
I not sure it necessary, but adding clientName to every event kinds seem wrong.

Example:
- Client A enable clientName tag. User use Client A to publish some events, example relay list (kind 10002), it also include clientName.
- Client B query user's relay list. Client B need to do extra step to ignore "client" tag

So I made this PR for update the scope of "clientName", it only present on kind 1 or kind 30023