### PR TITLE
NDKRelayUrl -> WebSocket["url"]

### DIFF
--- a/ndk/src/events/kinds/NDKRelayList.ts
+++ b/ndk/src/events/kinds/NDKRelayList.ts
@@ -2,7 +2,6 @@ import { NDKKind } from ".";
 import type { NostrEvent } from "..";
 import { NDKEvent } from "..";
 import type { NDK } from "../../ndk";
-import type { NDKRelayUrl } from "../../relay";
 
 const READ_MARKER = "read";
 const WRITE_MARKER = "write";
@@ -17,42 +16,42 @@ export class NDKRelayList extends NDKEvent {
         return new NDKRelayList(ndkEvent.ndk, ndkEvent.rawEvent());
     }
 
-    get readRelayUrls(): NDKRelayUrl[] {
+    get readRelayUrls(): WebSocket["url"][] {
         return this.getMatchingTags("r")
             .filter((tag) => !tag[2] || (tag[2] && tag[2] === READ_MARKER))
             .map((tag) => tag[1]);
     }
 
-    set readRelayUrls(relays: NDKRelayUrl[]) {
+    set readRelayUrls(relays: WebSocket["url"][]) {
         for (const relay of relays) {
             this.tags.push(["r", relay, READ_MARKER]);
         }
     }
 
-    get writeRelayUrls(): NDKRelayUrl[] {
+    get writeRelayUrls(): WebSocket["url"][] {
         return this.getMatchingTags("r")
             .filter((tag) => !tag[2] || (tag[2] && tag[2] === WRITE_MARKER))
             .map((tag) => tag[1]);
     }
 
-    set writeRelayUrls(relays: NDKRelayUrl[]) {
+    set writeRelayUrls(relays: WebSocket["url"][]) {
         for (const relay of relays) {
             this.tags.push(["r", relay, WRITE_MARKER]);
         }
     }
 
-    get bothRelayUrls(): NDKRelayUrl[] {
+    get bothRelayUrls(): WebSocket["url"][] {
         return this.getMatchingTags("r")
             .filter((tag) => !tag[2])
             .map((tag) => tag[1]);
     }
-    set bothRelayUrls(relays: NDKRelayUrl[]) {
+    set bothRelayUrls(relays: WebSocket["url"][]) {
         for (const relay of relays) {
             this.tags.push(["r", relay]);
         }
     }
 
-    get relays(): NDKRelayUrl[] {
+    get relays(): WebSocket["url"][] {
         return this.getMatchingTags("r").map((tag) => tag[1]);
     }
 }

--- a/ndk/src/ndk/index.ts
+++ b/ndk/src/ndk/index.ts
@@ -5,7 +5,7 @@ import type { NDKCacheAdapter } from "../cache/index.js";
 import dedupEvent from "../events/dedup.js";
 import type { NDKEvent, NDKEventId } from "../events/index.js";
 import { OutboxTracker } from "../outbox/tracker.js";
-import { NDKRelay, NDKRelayUrl } from "../relay/index.js";
+import { NDKRelay } from "../relay/index.js";
 import { NDKPool } from "../relay/pool/index.js";
 import { NDKRelaySet } from "../relay/sets/index.js";
 import { correctRelaySet } from "../relay/sets/utils.js";
@@ -112,7 +112,7 @@ export const DEFAULT_BLACKLISTED_RELAYS = [
 ];
 
 export class NDK extends EventEmitter {
-    public explicitRelayUrls?: NDKRelayUrl[];
+    public explicitRelayUrls?: WebSocket["url"][];
     public pool: NDKPool;
     public outboxPool?: NDKPool;
     private _signer?: NDKSigner;

--- a/ndk/src/outbox/tracker.ts
+++ b/ndk/src/outbox/tracker.ts
@@ -3,7 +3,6 @@ import { LRUCache } from "typescript-lru-cache";
 
 import type { NDKRelayList } from "../events/kinds/NDKRelayList.js";
 import type { NDK } from "../ndk/index.js";
-import type { NDKRelayUrl } from "../relay/index.js";
 import type { Hexpubkey } from "../user/index.js";
 import { NDKUser } from "../user/index.js";
 
@@ -24,10 +23,10 @@ export class OutboxItem {
     /**
      * The relay URLs that are of interest to this item
      */
-    public relayUrlScores: Map<NDKRelayUrl, number>;
+    public relayUrlScores: Map<WebSocket["url"], number>;
 
-    public readRelays: Set<NDKRelayUrl>;
-    public writeRelays: Set<NDKRelayUrl>;
+    public readRelays: Set<WebSocket["url"]>;
+    public writeRelays: Set<WebSocket["url"]>;
 
     constructor(type: OutboxItemType) {
         this.type = type;

--- a/ndk/src/relay/index.ts
+++ b/ndk/src/relay/index.ts
@@ -10,7 +10,8 @@ import type { NDKRelayScore } from "./score.js";
 import { NDKRelaySubscriptions } from "./subscriptions.js";
 import { NDKAuthPolicy } from "./auth-policies.js";
 
-export type NDKRelayUrl = string;
+/** @deprecated Use `WebSocket['url']` instead. */
+export type NDKRelayUrl = WebSocket["url"];
 
 export enum NDKRelayStatus {
     CONNECTING,
@@ -59,7 +60,7 @@ export interface NDKRelayConnectionStats {
  * @emits NDKRelay#auth when the relay requires authentication
  */
 export class NDKRelay extends EventEmitter {
-    readonly url: NDKRelayUrl;
+    readonly url: WebSocket["url"];
     readonly scores: Map<NDKUser, NDKRelayScore>;
     public connectivity: NDKRelayConnectivity;
     private subs: NDKRelaySubscriptions;
@@ -77,7 +78,7 @@ export class NDKRelay extends EventEmitter {
     public complaining = false;
     readonly debug: debug.Debugger;
 
-    public constructor(url: NDKRelayUrl, authPolicy?: NDKAuthPolicy) {
+    public constructor(url: WebSocket["url"], authPolicy?: NDKAuthPolicy) {
         super();
         this.url = url;
         this.scores = new Map<NDKUser, NDKRelayScore>();

--- a/ndk/src/relay/pool/index.ts
+++ b/ndk/src/relay/pool/index.ts
@@ -2,7 +2,6 @@ import type debug from "debug";
 import { EventEmitter } from "tseep";
 
 import type { NDK } from "../../ndk/index.js";
-import type { NDKRelayUrl } from "../index.js";
 import { NDKRelay, NDKRelayStatus } from "../index.js";
 
 export type NDKPoolStats = {
@@ -24,17 +23,17 @@ export type NDKPoolStats = {
  */
 export class NDKPool extends EventEmitter {
     // TODO: This should probably be an LRU cache
-    public relays = new Map<NDKRelayUrl, NDKRelay>();
-    public blacklistRelayUrls: Set<NDKRelayUrl>;
+    public relays = new Map<WebSocket["url"], NDKRelay>();
+    public blacklistRelayUrls: Set<WebSocket["url"]>;
     private debug: debug.Debugger;
-    private temporaryRelayTimers = new Map<NDKRelayUrl, NodeJS.Timeout>();
-    private flappingRelays: Set<NDKRelayUrl> = new Set();
+    private temporaryRelayTimers = new Map<WebSocket["url"], NodeJS.Timeout>();
+    private flappingRelays: Set<WebSocket["url"]> = new Set();
     // A map to store timeouts for each flapping relay.
     private backoffTimes: Map<string, number> = new Map();
 
     public constructor(
-        relayUrls: NDKRelayUrl[] = [],
-        blacklistedRelayUrls: NDKRelayUrl[] = [],
+        relayUrls: WebSocket["url"][] = [],
+        blacklistedRelayUrls: WebSocket["url"][] = [],
         ndk: NDK,
         debug?: debug.Debugger
     ) {
@@ -140,7 +139,7 @@ export class NDKPool extends EventEmitter {
      *
      * New relays will be attempted to be connected.
      */
-    public getRelay(url: NDKRelayUrl, connect = true): NDKRelay {
+    public getRelay(url: WebSocket["url"], connect = true): NDKRelay {
         let relay = this.relays.get(url);
 
         if (!relay) {

--- a/ndk/src/relay/sets/calculate.ts
+++ b/ndk/src/relay/sets/calculate.ts
@@ -2,7 +2,7 @@ import type { NDKEvent } from "../../events/index.js";
 import type { NDK } from "../../ndk/index.js";
 import type { NDKFilter } from "../../subscription/index.js";
 import type { Hexpubkey } from "../../user/index.js";
-import type { NDKRelay, NDKRelayUrl } from "../index.js";
+import type { NDKRelay } from "../index.js";
 import { NDKRelaySet } from "./index.js";
 
 /**
@@ -23,7 +23,7 @@ export function calculateRelaySetFromEvent(ndk: NDK, event: NDKEvent): NDKRelayS
     return new NDKRelaySet(relays, ndk);
 }
 
-export function getWriteRelaysFor(ndk: NDK, author: Hexpubkey): Set<NDKRelayUrl> | undefined {
+export function getWriteRelaysFor(ndk: NDK, author: Hexpubkey): Set<WebSocket["url"]> | undefined {
     if (!ndk.outboxTracker) return undefined;
 
     return ndk.outboxTracker.data.get(author)?.writeRelays;
@@ -40,8 +40,8 @@ export function getWriteRelaysFor(ndk: NDK, author: Hexpubkey): Set<NDKRelayUrl>
 export function calculateRelaySetsFromFilter(
     ndk: NDK,
     filters: NDKFilter[]
-): Map<NDKRelayUrl, NDKFilter[]> {
-    const result = new Map<NDKRelayUrl, NDKFilter[]>();
+): Map<WebSocket["url"], NDKFilter[]> {
+    const result = new Map<WebSocket["url"], NDKFilter[]>();
     const authors = new Set<Hexpubkey>();
 
     filters.forEach((filter) => {
@@ -53,7 +53,7 @@ export function calculateRelaySetsFromFilter(
     // if this filter has authors, get write relays for each
     // one of them and add them to the map
     if (authors.size > 0) {
-        const authorToRelaysMap = new Map<NDKRelayUrl, Hexpubkey[]>();
+        const authorToRelaysMap = new Map<WebSocket["url"], Hexpubkey[]>();
 
         // Go through each pubkey in `authors`
         for (const author of authors) {
@@ -70,7 +70,7 @@ export function calculateRelaySetsFromFilter(
                 });
             } else {
                 // If we don't, add the explicit relays
-                ndk.explicitRelayUrls?.forEach((relay: NDKRelayUrl) => {
+                ndk.explicitRelayUrls?.forEach((relay: WebSocket["url"]) => {
                     const authorsInRelay = authorToRelaysMap.get(relay) || [];
                     authorsInRelay.push(author);
                     authorToRelaysMap.set(relay, authorsInRelay);
@@ -100,7 +100,7 @@ export function calculateRelaySetsFromFilter(
         }
     } else {
         // If we don't, add the explicit relays
-        ndk.explicitRelayUrls?.forEach((relay: NDKRelayUrl) => {
+        ndk.explicitRelayUrls?.forEach((relay: WebSocket["url"]) => {
             result.set(relay, filters);
         });
     }
@@ -116,6 +116,6 @@ export function calculateRelaySetsFromFilter(
 export function calculateRelaySetsFromFilters(
     ndk: NDK,
     filters: NDKFilter[]
-): Map<NDKRelayUrl, NDKFilter[]> {
+): Map<WebSocket["url"], NDKFilter[]> {
     return calculateRelaySetsFromFilter(ndk, filters);
 }

--- a/ndk/src/subscription/index.ts
+++ b/ndk/src/subscription/index.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "tseep";
 import type { NDKEvent, NDKEventId } from "../events/index.js";
 import type { NDKKind } from "../events/kinds/index.js";
 import type { NDK } from "../ndk/index.js";
-import type { NDKRelay, NDKRelayUrl } from "../relay";
+import type { NDKRelay } from "../relay";
 import type { NDKPool } from "../relay/pool/index.js";
 import { calculateRelaySetsFromFilters } from "../relay/sets/calculate";
 import type { NDKRelaySet } from "../relay/sets/index.js";
@@ -113,7 +113,7 @@ export class NDKSubscription extends EventEmitter {
     /**
      * Tracks the filters as they are executed on each relay
      */
-    public relayFilters?: Map<NDKRelayUrl, NDKFilter[]>;
+    public relayFilters?: Map<WebSocket["url"], NDKFilter[]>;
     public relaySet?: NDKRelaySet;
     public ndk: NDK;
     public debug: debug.Debugger;


### PR DESCRIPTION
`NDKRelayUrl` is overkill because it's a primitive type (`string`), making it difficult for first-timers of the codebase to understand what it is.

However, using `string` is too ambiguous in some situations, especially ones like `Map<string, Thingy>`.

Instead, it's a neat trick to use `WebSocket["url"]`. This has a number of advantages:

- You don't need to import it to use it.
- A first-time reader will immediately understand what it means.
- It's better than `wss://${string}` because it doesn't narrow the type at all, it's still just a `string`.
- It's a general term that can be used between both Nostr relays and WebSocket implementations in general.