### PR TITLE
Fix type of Filter

### DIFF
--- a/ndk/src/subscription/index.ts
+++ b/ndk/src/subscription/index.ts
@@ -17,7 +17,7 @@ export type NDKFilter<K extends number = NDKKind> = {
     until?: number;
     limit?: number;
     search?: string;
-    [key: `#${string}`]: string[];
+    [key: `#${string}`]: string[] | undefined;
 };
 
 export enum NDKSubscriptionCacheUsage {


### PR DESCRIPTION
Currently the Filter type from Nostr Tools cannot be passed into NDK functions due to incompatibility of tag queries. They were updated in: https://github.com/nbd-wtf/nostr-tools/pull/274 This PR updates the types to restore compat. It will continue to work with older versions and shouldn't break any existing code since it widens the type rather than narrowing it.