### PR TITLE
adding option to pass array of kinds to NDKFilter type

### DIFF
--- a/ndk/src/subscription/index.ts
+++ b/ndk/src/subscription/index.ts
@@ -9,9 +9,9 @@ import { calculateRelaySetsFromFilters } from "../relay/sets/calculate";
 import type { NDKRelaySet } from "../relay/sets/index.js";
 import { queryFullyFilled } from "./utils.js";
 
-export type NDKFilter<K extends number = NDKKind> = {
+export type NDKFilter<K extends number | number[] = NDKKind> = {
     ids?: string[];
-    kinds?: K[];
+    kinds?: K extends any[] ? K : K[];
     authors?: string[];
     since?: number;
     until?: number;


### PR DESCRIPTION
Changes the NDKFilter type definition to allow an array of kinds to be passed as the generic rather than just a single kind number. This change still allows for a single number to be passed as the generic so it will not cause any new ts error, but will now enable users to pass an array as well.