### PR TITLE
picture before image

### DIFF
--- a/ndk/src/user/profile.ts
+++ b/ndk/src/user/profile.ts
@@ -38,7 +38,7 @@ export function profileFromEvent(event: NDKEvent): NDKUserProfile {
                 break;
             case "image":
             case "picture":
-                profile.image = payload.image || payload.picture;
+                profile.image = payload.picture || payload.image;
                 break;
             case "banner":
                 profile.banner = payload.banner;


### PR DESCRIPTION
Hi there,

I noticed that the current implementation of ndk assigns the value of `payload.image` to the `profile.image` property, but according to the protocol specification we should prioritize the `payload.picture` property if it's present. I noticed this recently on a profile where both picture and image were present, and it took image instead of picture, causing the profile to display incorrectly.
