### PR TITLE
Ignore duplicates of auth_url

### DIFF
--- a/ndk/src/signers/nip46/rpc.ts
+++ b/ndk/src/signers/nip46/rpc.ts
@@ -121,10 +121,14 @@ export class NDKNostrRpc extends EventEmitter {
         const remoteUser = this.ndk.getUser({ hexpubkey: remotePubkey });
         const request = { id, method, params };
         const promise = new Promise<NDKRpcResponse>((resolve) => {
+            let gotAuth = false
             const responseHandler = (response: NDKRpcResponse) => {
                 if (response.result === "auth_url") {
                     this.once(`response-${id}`, responseHandler);
-                    this.emit("authUrl", response.error);
+                    if (!gotAuth) {
+                        gotAuth = true
+                        this.emit("authUrl", response.error);
+                    }
                 } else if (cb) {
                     cb(response);
                 }


### PR DESCRIPTION
Users can put nsecs into many bunkers and they all can send auth_url to the same req, just like dups of nip46 replies are ignored, dups of auth_url should be ignored too.