### PR TITLE
Update docs: closeOnEose defaults to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,8 +270,7 @@ But if NDK has observed that `npub-B` tends to write to `wss://userb.xyz` and
 ## Auto-closing subscriptions
 
 Often, clients need to fetch data but don't need to maintain an open connection to the relay. This is true of profile metadata requests especially.
-_NDK defaults to having the `closeOnEose` flag set to `true`, to make permanent subscriptions explicit in the codebase; if you want your
-subscription to remain active beyond `EOSE`, you should set it to `false`._
+_NDK defaults to having the `closeOnEose` flag set to `false`; if you want your subscription to close after `EOSE`, you should set it to `true`._
 
 -   The `closeOnEose` flag will make the connection close immediately after EOSE is seen.
 


### PR DESCRIPTION
`false` appears to be the real default: https://github.com/nostr-dev-kit/ndk/blob/e18ce4026f2633c343959d73d85c0682e8ebe6fa/ndk/src/subscription/index.ts#L100