### PR TITLE
Fix for silently failing NIP05 fetch from nsec.app

### DIFF
--- a/ndk/src/user/nip05.test.ts
+++ b/ndk/src/user/nip05.test.ts
@@ -1,0 +1,40 @@
+import { getNip05For } from "./nip05";
+
+describe("nip05", () => {
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe("getNip05For", () => {
+
+        it("should parse nip46 relays even without relays being specified ", async () => {
+
+            const json = {
+                names: {
+                    bob: "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9",
+                },
+                nip46: {
+                    b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9: [
+                        "wss://relay.nsec.app",
+                        "wss://other-relay.org",
+                    ],
+                },
+            };
+
+            const fetchMock = jest.fn(() =>
+                Promise.resolve({
+                    json: (): Promise<any> => Promise.resolve(json),
+                } as Response)
+            ) as jest.Mock;
+
+            const result = await getNip05For("bob@nsec.app", fetchMock);
+
+            expect(result?.pubkey).toEqual(
+                "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9"
+            );
+
+            expect(result?.nip46).toEqual(["wss://relay.nsec.app", "wss://other-relay.org"]);
+        });
+    });
+});

--- a/ndk/src/user/nip05.ts
+++ b/ndk/src/user/nip05.ts
@@ -64,7 +64,7 @@ function parseNIP05Result(json: any): NIP05Result {
 
     if (json.nip46) {
         result.nip46 = {};
-        for (const [pubkey, nip46] of Object.entries(json.relays)) {
+        for (const [pubkey, nip46] of Object.entries(json.nip46)) {
             if (typeof pubkey === "string" && Array.isArray(nip46)) {
                 result.nip46[pubkey] = nip46.filter((relay: unknown) => typeof relay === "string");
             }


### PR DESCRIPTION
There is a bug in the nip05 implementation that occurs when no relays are specified.  Currently this is an issue with *nsec.app* where only `names` and `nip46` appear in the `nip05` json.

It **silently** fails fetching the `nip05` data.

- This was probably a copy paste mistake. 
- I have added a unit test failed prior to the change. 
- The error handling `catch { return null }` hides the error but I didn't want to change the behaviour.
