### PR TITLE
Improve hashtag regex

### DIFF
--- a/ndk/src/events/content-tagger.ts
+++ b/ndk/src/events/content-tagger.ts
@@ -76,7 +76,7 @@ export async function generateContentTags(
     tags: NDKTag[] = []
 ): Promise<ContentTag> {
     const tagRegex = /(@|nostr:)(npub|nprofile|note|nevent|naddr)[a-zA-Z0-9]+/g;
-    const hashtagRegex = /#(\w+)/g;
+    const hashtagRegex = /(?<=\s)(#[^\s!@#$%^&*()=+.\/,\[{\]};:'"?><]+)/g;
     let promises: Promise<void>[] = [];
 
     const addTagIfNew = (t: NDKTag) => {

--- a/ndk/src/events/content-tagger.ts
+++ b/ndk/src/events/content-tagger.ts
@@ -76,7 +76,7 @@ export async function generateContentTags(
     tags: NDKTag[] = []
 ): Promise<ContentTag> {
     const tagRegex = /(@|nostr:)(npub|nprofile|note|nevent|naddr)[a-zA-Z0-9]+/g;
-    const hashtagRegex = /(?<=\s)(#[^\s!@#$%^&*()=+.\/,\[{\]};:'"?><]+)/g;
+    const hashtagRegex = /(?<=\s|^)(#[^\s!@#$%^&*()=+.\/,\[{\]};:'"?><]+)/g;
     let promises: Promise<void>[] = [];
 
     const addTagIfNew = (t: NDKTag) => {


### PR DESCRIPTION
- Match all non space and punctuation characters
- Require a space character before the hashtag to avoid matching URL fragments, see https://github.com/verbiricha/habla.news/issues/163