### PR TITLE
Fix parsing of nip04 decryption response in NDKNip46Signer

### DIFF
--- a/ndk/src/signers/nip46/index.ts
+++ b/ndk/src/signers/nip46/index.ts
@@ -210,8 +210,7 @@ export class NDKNip46Signer extends EventEmitter implements NDKSigner {
                 24133,
                 (response: NDKRpcResponse) => {
                     if (!response.error) {
-                        const value = JSON.parse(response.result);
-                        resolve(value[0]);
+                        resolve(response.result);
                     } else {
                         reject(response.error);
                     }


### PR DESCRIPTION
NIP46: Fixed wrong parsing of rpc response when requesting decryption from bunker

- The JSON.parse() call resulted in exception being thrown since 'response.result' is not a valid JSON string
fixed #203