### PR TITLE
add created_at to NDKUserProfile

### DIFF
--- a/ndk/src/user/profile.ts
+++ b/ndk/src/user/profile.ts
@@ -4,7 +4,8 @@ import type { NDKEvent } from "../events/index.js";
  * NDKUserProfile represents a user's kind 0 profile metadata
  */
 export interface NDKUserProfile {
-    [key: string]: string | undefined; // allows custom fields
+    [key: string]: string | number | undefined; // allows custom fields
+    created_at?: number;
     name?: string;
     displayName?: string;
     image?: string;
@@ -34,11 +35,11 @@ export function profileFromEvent(event: NDKEvent): NDKUserProfile {
                 profile.name = payload.name;
                 break;
             case "display_name":
-                profile.displayName = payload.display_name;
+                profile.displayName = payload.display_name as string;
                 break;
             case "image":
             case "picture":
-                profile.image = payload.picture || payload.image;
+                profile.image = (payload.picture || payload.image) as string;
                 break;
             case "banner":
                 profile.banner = payload.banner;
@@ -74,14 +75,14 @@ export function profileFromEvent(event: NDKEvent): NDKUserProfile {
 }
 
 export function serializeProfile(profile: NDKUserProfile): string {
-    const payload: any = {};
+    const payload: NDKUserProfile = {};
 
     // Remap some keys from bad clients into good ones per NIP-24
     for (const [key, val] of Object.entries(profile)) {
         switch (key) {
             case "username":
             case "name":
-                payload.name = val;
+                payload.name = val as string;
                 break;
             case "displayName":
                 payload.display_name = val;
@@ -92,7 +93,7 @@ export function serializeProfile(profile: NDKUserProfile): string {
                 break;
             case "bio":
             case "about":
-                payload.about = val;
+                payload.about = val as string;
                 break;
             default:
                 payload[key] = val;


### PR DESCRIPTION
- fix ts errors by type hints

When NDK fetches the user profile and copies it into an NDKUserProfile object, it always adds the created_at: number. This patch is simply updating the NDKUserProfile interface to reflect the existence of the created_at key. I am in favor of having the created_at key because I have a use case where I need to know how old the profile is.