### PR TITLE
fix nip46 login with nip05

### DIFF
--- a/ndk/src/signers/nip46/index.ts
+++ b/ndk/src/signers/nip46/index.ts
@@ -136,13 +136,13 @@ export class NDKNip46Signer extends EventEmitter implements NDKSigner {
         const remoteUser = this.ndk.getUser({ pubkey: this.remotePubkey });
 
         if (this.nip05 && !this.remotePubkey) {
-            NDKUser.fromNip05(this.nip05).then((user) => {
-                if (user) {
-                    this.remoteUser = user;
-                    this.remotePubkey = user.pubkey;
-                    this.relayUrls = user.nip46Urls;
-                }
-            });
+            const user = await NDKUser.fromNip05(this.nip05, this.ndk);
+
+            if (user) {
+                this.remoteUser = user;
+                this.remotePubkey = user.pubkey;
+                this.relayUrls = user.nip46Urls;
+            }
         }
 
         if (!this.remotePubkey) {


### PR DESCRIPTION
- added `ndk` instance to `NDKUser.fromNip05` to fix `No NDK instance found` error.
- replaced `Promise.then` with `await` to wait for the NDKUser and fix `Remote pubkey not set` error.