### PR TITLE
fix dexie cache filter

### DIFF
--- a/ndk-cache-dexie/src/index.ts
+++ b/ndk-cache-dexie/src/index.ts
@@ -323,7 +323,7 @@ export default class NDKCacheAdapterDexie implements NDKCacheAdapter {
     }
 
     public addUnpublishedEvent = addUnpublishedEvent.bind(this);
-    
+
     public async setEvent(event: NDKEvent, filters: NDKFilter[], relay?: NDKRelay): Promise<void> {
         if (event.kind === 0) {
             if (!this.profiles) return;
@@ -541,7 +541,7 @@ export function foundEvent(
     try {
         const deserializedEvent = deserialize(event.event);
 
-        if (filter && !matchFilter(filter, deserializedEvent as any)) return;
+        if (filter && !matchFilter(filter, event)) return;
 
         const ndkEvent = new NDKEvent(undefined, deserializedEvent);
         const relay = relayUrl ? subscription.pool.getRelay(relayUrl) : undefined;
@@ -558,12 +558,12 @@ export function foundEvent(
  */
 function getIndexableTags(event: NDKEvent): NDKTag[] {
     let indexableTags: NDKTag[] = [];
-    
+
     if (event.kind === 3) return [];
-    
+
     for (const tag of event.tags) {
         if (tag[0].length !== 1) continue;
-        
+
         indexableTags.push(tag);
 
         if (indexableTags.length >= INDEXABLE_TAGS_LIMIT) return [];


### PR DESCRIPTION
by correcting the event format passed to nostr-tool's matchFilter

the dexie cache adaptor applies some simple filtering for efficiency reasons before using nostr-tool's matchFilter to apply the full NIP-01 ruleset

basic root cause analysis:

it is likely that nostr-tools changed the event format expected by matchFilter and this was missed during a dependancy upgrade for a number of reasons:

1. the use of `as any` remove type checking
2. nostr-tools doesn't use semantic versioning to highlight breaking changes
3. a cursory test using simple filters would have returned correct results