### PR TITLE
add dexie cache kind index

### DIFF
--- a/ndk-cache-dexie/src/caches/event-kinds.ts
+++ b/ndk-cache-dexie/src/caches/event-kinds.ts
@@ -1,0 +1,38 @@
+import type { Table } from "dexie";
+import type { CacheHandler } from "../lru-cache";
+import type debug from "debug";
+import type { EventKind } from "../db";
+import type { LRUCache } from "typescript-lru-cache";
+
+export type EventKindCacheEntry = string;
+
+export async function eventKindsWarmUp(
+    cacheHandler: CacheHandler<EventKindCacheEntry>,
+    eventKinds: Table<EventKind>,
+) {
+    const array = await eventKinds.limit(cacheHandler.maxSize).toArray();
+    for (const event of array) {
+        cacheHandler.add(event.kind, event.eventId, false);
+    }
+}
+
+export const eventKindsDump = (eventKinds: Table<EventKind>, debug: debug.IDebugger) => {
+    return async (dirtyKeys: Set<string>, cache: LRUCache<string, EventKindCacheEntry>) => {
+        const entries = [];
+
+        for (const kind of dirtyKeys) {
+            const eventIds = cache.get(kind);
+            if (eventIds) {
+                for (const eventId of eventIds)
+                    entries.push({ kind, eventId });
+            }
+        }
+
+        if (entries.length > 0) {
+            debug(`Saving ${entries.length} events cache entries to database`);
+            await eventKinds.bulkPut(entries);
+        }
+
+        dirtyKeys.clear();
+    };
+};

--- a/ndk-cache-dexie/src/db.ts
+++ b/ndk-cache-dexie/src/db.ts
@@ -21,6 +21,11 @@ export interface EventTag {
     tagValue: string;
 }
 
+export interface EventKind {
+    eventId: string;
+    kind: string;
+}
+
 export interface Nip05 {
     nip05: string;
     profile: string | null;
@@ -50,17 +55,19 @@ export class Database extends Dexie {
     users!: Table<User>;
     events!: Table<Event>;
     eventTags!: Table<EventTag>;
+    eventKinds!: Table<EventKind>;
     nip05!: Table<Nip05>;
     lnurl!: Table<Lnurl>;
     relayStatus!: Table<RelayStatus>;
-    unpublishedEvents!: Table<UnpublishedEvent & {id: NDKEventId}>;
+    unpublishedEvents!: Table<UnpublishedEvent & { id: NDKEventId }>;
 
     constructor(name: string) {
         super(name);
-        this.version(13).stores({
+        this.version(14).stores({
             users: "&pubkey",
             events: "&id, kind",
             eventTags: "&tagValue",
+            eventKinds: "&kind",
             nip05: "&nip05",
             lnurl: "&pubkey",
             relayStatus: "&url",

--- a/ndk-cache-dexie/src/index.ts
+++ b/ndk-cache-dexie/src/index.ts
@@ -323,7 +323,7 @@ export default class NDKCacheAdapterDexie implements NDKCacheAdapter {
     }
 
     public addUnpublishedEvent = addUnpublishedEvent.bind(this);
-    
+
     public async setEvent(event: NDKEvent, filters: NDKFilter[], relay?: NDKRelay): Promise<void> {
         if (event.kind === 0) {
             if (!this.profiles) return;
@@ -541,7 +541,7 @@ export function foundEvent(
     try {
         const deserializedEvent = deserialize(event.event);
 
-        if (filter && !matchFilter(filter, deserializedEvent as any)) return;
+        if (filter && !matchFilter(filter, event)) return;
 
         const ndkEvent = new NDKEvent(undefined, deserializedEvent);
         const relay = relayUrl ? subscription.pool.getRelay(relayUrl) : undefined;
@@ -558,12 +558,12 @@ export function foundEvent(
  */
 function getIndexableTags(event: NDKEvent): NDKTag[] {
     let indexableTags: NDKTag[] = [];
-    
+
     if (event.kind === 3) return [];
-    
+
     for (const tag of event.tags) {
         if (tag[0].length !== 1) continue;
-        
+
         indexableTags.push(tag);
 
         if (indexableTags.length >= INDEXABLE_TAGS_LIMIT) return [];


### PR DESCRIPTION
to support a wider range of filter

dexie cache only returns results when the supplied filter relates
to an existing index. presumably full support for filtering rules
per NIP-01 was ommited due to the performance cost of dumping all
cached entries and running them through nostr-tool's matchFilter.

Is this the case, or did the need never come up in the first place?

adding a 'kind' index expands the filters supported in a way that is
particularly useful for 'other stuff' apps which deal with kinds
with much fewer events.

eg {kinds: [3018], since: 1718023733}

very common kinds (0, 1, 3) are omitted for efficiency