### PR TITLE
fixes: #246 - auth was not being emitted when using nip07 signer

### DIFF
--- a/ndk/src/relay/connectivity.ts
+++ b/ndk/src/relay/connectivity.ts
@@ -77,6 +77,8 @@ export class NDKRelayConnectivity {
                         this.relay.auth(async (evt: EventTemplate): Promise<VerifiedEvent> => {
                             return res.rawEvent() as VerifiedEvent;
                         });
+                        this._status = NDKRelayStatus.CONNECTED;
+                        this.ndkRelay.emit("authed");
                     }
 
                     if (res === true) {


### PR DESCRIPTION
Similar to line 97, which I assume is being used for nsecbunker login, the event was not being emitted after a successful auth.