### PR TITLE
30818 component powered by svelte-asciidoc

### DIFF
--- a/ndk-svelte-components/package.json
+++ b/ndk-svelte-components/package.json
@@ -84,6 +84,7 @@
     "rehype-autolink-headings": "^7.0.0",
     "rehype-slug": "^6.0.0",
     "sanitize-html": "^2.11.0",
+    "svelte-asciidoc": "^0.0.2",
     "svelte-preprocess": "^5.0.4",
     "svelte-time": "^0.8.3"
   },

--- a/ndk-svelte-components/src/lib/event/content/EventContent.svelte
+++ b/ndk-svelte-components/src/lib/event/content/EventContent.svelte
@@ -10,6 +10,7 @@
     import Kind30000 from "./Kind30000.svelte";
     import Kind30001 from "./Kind30001.svelte";
     import Kind30023 from "./Kind30023.svelte";
+    import Kind30818 from "./Kind30818.svelte";
     import type { SvelteComponent } from "svelte";
     import type { MarkedExtension } from "marked";
     import type { UrlFactory, UrlType } from "$lib";
@@ -44,7 +45,7 @@
      */
     export let content = event?.content;
 
-    const markdownKinds = [ NDKKind.Article, 30041, NDKKind.Wiki ]
+    const markdownKinds = [ NDKKind.Article, 30041 ]
 </script>
 
 {#if event}
@@ -72,6 +73,14 @@
             on:click
             class={$$props.class}
             {markedExtensions}
+        />
+    {:else if event.kind === 30818}
+        <Kind30818
+            {ndk}
+            {event}
+            {...$$props}
+            on:click
+            class={$$props.class}
         />
     {:else}
         <Kind1

--- a/ndk-svelte-components/src/lib/event/content/Kind30818.svelte
+++ b/ndk-svelte-components/src/lib/event/content/Kind30818.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+    import { createEventDispatcher } from 'svelte';
+    import type NDK from "@nostr-dev-kit/ndk"; import { NDKEvent } from "@nostr-dev-kit/ndk";
+    import SvelteAsciidoc from "svelte-asciidoc";
+    import AsciidocWikiLinkOrReferenceComponent from "../../utils/components/AsciidocWikiLinkOrReferenceComponent.svelte";
+
+    export let ndk: NDK;
+    export let event: NDKEvent;
+
+    const dispatch = createEventDispatcher();
+
+    const content = event.content.replace(/\[\[(.*?)\]\]/g, (_: string, content: string) => {
+      let [target, display] = content.split('|');
+      display = display || target;
+      target = normalizeArticleName(target);
+      return `link:wikilink:${target}[${display}]`;
+    }).replace(/\bnostr:[0-9a-z]{50,}/g, (match: string) => 'link:' + match);
+
+    function normalizeArticleName(input: string): string {
+      return input.trim().toLowerCase().replace(/\W/g, '-');
+    }
+</script>
+
+<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+<div class="wiki-article {$$props.class??""}" on:click>
+    <SvelteAsciidoc
+      source={content}
+      naturalRenderers={{ a: AsciidocWikiLinkOrReferenceComponent}}
+      extra={{dispatch, ndk}}
+    />
+</div>
+
+<style lang="postcss">
+    * > :global(.article img) {
+        object-fit: contain;
+        width: 100%;
+        height: 100%;
+    }
+</style>

--- a/ndk-svelte-components/src/lib/utils/components/AsciidocWikiLinkOrReferenceComponent.svelte
+++ b/ndk-svelte-components/src/lib/utils/components/AsciidocWikiLinkOrReferenceComponent.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { getExtra } from 'svelte-asciidoc';
+  import { decode, npubEncode } from "nostr-tools/nip19";
+  import type NDK from "@nostr-dev-kit/ndk";
+  import type { NDKUserProfile } from '@nostr-dev-kit/ndk';
+
+  export let attrs: { [_: string]: string };
+
+  const { href } = attrs;
+  const { dispatch, ndk }: { dispatch: ((ev: string, opts: any) => void), ndk: NDK } = getExtra()
+
+  let slotted: HTMLAnchorElement
+  let useSlotted = true
+
+  let wikitarget: string | undefined;
+  let npub: string | undefined;
+  let profile: NDKUserProfile | undefined;
+  let name: string | undefined;
+  $: shortNpub = npub && (npub.substring(0, 7) + '…' + npub.substring(58))
+
+  if (href.startsWith('wikilink:')) {
+    wikitarget = href.substring(9);
+  } else if (href.startsWith('nostr:npub1')) {
+    npub = href.substring(6)
+  } else if (href.startsWith('nostr:nprofile1')) {
+    let {data} = decode(href.substring(6))
+    npub = npubEncode(data)
+  }
+
+  // fetch metadata from referenced nostruser so we can display nicer links
+  onMount(() => {
+    if (npub) {
+      let slottedContent = slotted.textContent!
+      useSlotted = false
+
+      if (slottedContent === href) {
+        let user = ndk.getUser({npub})
+        profile = user.profile
+        user.fetchProfile().then(p => {
+          profile = p || undefined
+          name = p?.name || p?.displayName || shortNpub
+        })
+      } else {
+        name = slottedContent
+      }
+    }
+  })
+
+  function handleProfileClick(e: MouseEvent) {
+    e.preventDefault()
+    dispatch('click', {
+      type: 'profile',
+      npub,
+      ...profile,
+    })
+  }
+
+  function handleWikilinkClick(e: MouseEvent) {
+    e.preventDefault()
+    dispatch('click', {
+      type: 'wikilink',
+      target: wikitarget,
+    })
+  }
+</script>
+
+{#if wikitarget}
+  <a
+    title={`wikilink to: "${wikitarget}"`}
+    href={`/${wikitarget}`} on:click={handleWikilinkClick}><slot /></a
+  >
+{:else if npub}
+  {#if useSlotted}
+    <a href={`/${npub}`} on:click={handleProfileClick} bind:this={slotted}><slot /></a>
+  {:else}
+    <a href={`/${npub}`} on:click={handleProfileClick}>{name}</a>
+  {/if}
+{:else}
+  <!-- svelte-ignore a11y-missing-attribute -->
+  <a target="_blank" {...attrs}>
+    <slot />
+    <svg
+      class="align-text-top h-3.5 inline pl-1"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      >
+          <path
+            d="M10.0002 5H8.2002C7.08009 5 6.51962 5 6.0918 5.21799C5.71547 5.40973 5.40973 5.71547 5.21799 6.0918C5 6.51962 5 7.08009 5 8.2002V15.8002C5 16.9203 5 17.4801 5.21799 17.9079C5.40973 18.2842 5.71547 18.5905 6.0918 18.7822C6.5192 19 7.07899 19 8.19691 19H15.8031C16.921 19 17.48 19 17.9074 18.7822C18.2837 18.5905 18.5905 18.2839 18.7822 17.9076C19 17.4802 19 16.921 19 15.8031V14M20 9V4M20 4H15M20 4L13 11"
+            stroke="#888888"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ></path>
+      </svg
+    >
+  </a>
+{/if}


### PR DESCRIPTION
Some of this was already merged on c902bc2850c3cede77e9f3859a468150239efa1a but got reverted later in a big commit bundle apparently.

This has slight modifications for displaying Nostr entities and making npub/nprofile links display a name and be specially clickable with a custom event.