### PR TITLE
drop shitty markdown "transition syntax" support on kind 30818

### DIFF
--- a/ndk-svelte-components/package.json
+++ b/ndk-svelte-components/package.json
@@ -84,7 +84,7 @@
     "rehype-autolink-headings": "^7.0.0",
     "rehype-slug": "^6.0.0",
     "sanitize-html": "^2.11.0",
-    "svelte-asciidoc": "^0.0.2",
+    "svelte-asciidoc": "^0.0.5",
     "svelte-preprocess": "^5.0.4",
     "svelte-time": "^0.8.3"
   },

--- a/ndk-svelte-components/src/lib/event/content/Kind30818.svelte
+++ b/ndk-svelte-components/src/lib/event/content/Kind30818.svelte
@@ -24,6 +24,7 @@
 <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
 <div class="wiki-article {$$props.class??""}" on:click>
     <SvelteAsciidoc
+      supportMarkdownTransition={event.created_at < 1725159600}
       source={content}
       naturalRenderers={{ a: AsciidocWikiLinkOrReferenceComponent}}
       extra={{dispatch, ndk}}


### PR DESCRIPTION
`<SvelteAsciidoc />` was doing that by default for everybody, now it will do it only for articles published after 2024-09-01 (hardcoded date), so people are forced to write real Asciidoc.