### PR TITLE
update svelte-asciidoc

### DIFF
--- a/ndk-svelte-components/package.json
+++ b/ndk-svelte-components/package.json
@@ -84,7 +84,7 @@
     "rehype-autolink-headings": "^7.0.0",
     "rehype-slug": "^6.0.0",
     "sanitize-html": "^2.11.0",
-    "svelte-asciidoc": "^0.0.2",
+    "svelte-asciidoc": "0.0.6",
     "svelte-preprocess": "^5.0.4",
     "svelte-time": "^0.8.3"
   },

--- a/ndk-svelte-components/src/lib/event/content/Kind30818.svelte
+++ b/ndk-svelte-components/src/lib/event/content/Kind30818.svelte
@@ -24,6 +24,7 @@
 <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
 <div class="wiki-article {$$props.class??""}" on:click>
     <SvelteAsciidoc
+      supportMarkdownTransition={event.created_at < 1726282800}
       source={content}
       naturalRenderers={{ a: AsciidocWikiLinkOrReferenceComponent}}
       extra={{dispatch, ndk}}


### PR DESCRIPTION
this fixes an issue with tables.

it also introduces a way to disable the markdown transitional syntax that makes the asciidoc parser understand some random markdown syntax directives like "#" (which should be "=" in asciidoc) and just confuses everybody.

it should have been disabled since day one, but since I missed that this commit keeps it for all articles in the past and disables it only for events authored after 2024-09-14 (two weeks expected for this change to be deployed).


https://github.com/user-attachments/assets/439ef950-44f5-480e-9c83-1687bccddb0f

