### PR TITLE
Fix reconnection issues in `@nostr-dev-kit/ndk`

### DIFF
--- a/ndk/src/relay/connectivity.ts
+++ b/ndk/src/relay/connectivity.ts
@@ -65,7 +65,7 @@ export class NDKRelayConnectivity {
      * @returns A Promise that resolves when the connection is established, or rejects if the connection fails.
      */
     public async connect(timeoutMs?: number, reconnect = true): Promise<void> {
-        if (this._status !== NDKRelayStatus.DISCONNECTED || this.reconnectTimeout) {
+        if ((this._status !== NDKRelayStatus.RECONNECTING && this._status !== NDKRelayStatus.DISCONNECTED) || this.reconnectTimeout) {
             this.debug(
                 "Relay requested to be connected but was in state %s or it had a reconnect timeout",
                 this._status
@@ -179,8 +179,8 @@ export class NDKRelayConnectivity {
         if (this._status === NDKRelayStatus.CONNECTED) {
             this.handleReconnection();
         }
-        this.ndkRelay.emit("disconnect");
         this._status = NDKRelayStatus.DISCONNECTED;
+        this.ndkRelay.emit("disconnect");
     }
 
     /**


### PR DESCRIPTION
### Description
This pull request addresses issues with the `@nostr-dev-kit/ndk` package, specifically related to reconnection management with relays. The package was not properly handling relay reconnections, resulting in failed re-subscriptions.

### The Problem
The issue arises due to an interaction between the `handleReconnection` and `connect` functions. Here's a breakdown of the problem:

1. The reconnection function sets `reconnectTimeout` to `undefined` and updates the state to `"reconnecting"`. ([preview](https://github.com/nostr-dev-kit/ndk/blob/28b5246ee0e9e5754cbcc3a68f5049b0aead2dd2/ndk/src/relay/connectivity.ts#L448))
2. It then calls `connect()`, which contains the following check at the beginning ([preview](https://github.com/nostr-dev-kit/ndk/blob/28b5246ee0e9e5754cbcc3a68f5049b0aead2dd2/ndk/src/relay/connectivity.ts#L68))

    ```typescript
    if (this._status !== NDKRelayStatus.DISCONNECTED || this.reconnectTimeout) {
        this.debug(
            "Relay requested to be connected but was in state %s or it had a reconnect timeout",
            this._status
        );
        return;
    }
    ```

3. This causes the reconnection to always fail since `_status` is never set to `DISCONNECTED`.

### The Solution
To address this, I adjusted the logic to consider both cases by adding an additional condition:

```typescript
if ((this._status !== NDKRelayStatus.RECONNECTING && this._status !== NDKRelayStatus.DISCONNECTED) || this.reconnectTimeout) {
    this.debug(
        "Relay requested to be connected but was in state %s or it had a reconnect timeout",
        this._status
    );
    return;
}
```

By implementing this change, the issue was resolved on my end. The relay now reconnects and re-subscribes automatically. I'm not entirely sure if this is the preferred approach, but it provides an immediate fix for the problem.

## Additional Change
Additionally, I made a minor modification in the onDisconnect function of NDKRelayConnectivity:

```typescript
this.ndkRelay.emit("disconnect");
this._status = NDKRelayStatus.DISCONNECTED;
```

was changed to:

```typescript
this._status = NDKRelayStatus.DISCONNECTED;
this.ndkRelay.emit("disconnect");
```

The reason for this change is that when a listener is subscribed to the "relay:disconnect" event, it was receiving the event with the relay still in a connected state. This adjustment ensures that the relay status is correctly updated before emitting the event.