### PR TITLE
get bunker pubkey from pathname when hostname is empty

### DIFF
--- a/ndk/src/signers/nip46/index.ts
+++ b/ndk/src/signers/nip46/index.ts
@@ -95,7 +95,7 @@ export class NDKNip46Signer extends EventEmitter implements NDKSigner {
 
     private connectionTokenInit(connectionToken: string) {
         const bunkerUrl = new URL(connectionToken);
-        const bunkerPubkey = bunkerUrl.hostname;
+        const bunkerPubkey = bunkerUrl.hostname || bunkerUrl.pathname.replace(/^\/\//, "");
         const userPubkey = bunkerUrl.searchParams.get("pubkey");
         const relayUrls = bunkerUrl.searchParams.getAll("relay");
         const secret = bunkerUrl.searchParams.get("secret");


### PR DESCRIPTION
I'm running into an issue where the bunker pubkey is not set when trying to use bunker URLs from nsec.app like bunker://4b5893bff39aca8e3e3813c190156165e706d15d4f6136d718158ef957f26309?relay=wss://relay.nsec.app&secret=secret-value.

The `hostname` is empty and the `pathname` is `//4b5893bff39aca8e3e3813c190156165e706d15d4f6136d718158ef957f26309`. This PR makes sure to get the pubkey from pathname when the hostname is empty.