### PR TITLE
NDKNwc.fromURI always throws 'pubkey not set' in browser

### DIFF
--- a/ndk-wallet/src/wallets/nwc/index.ts
+++ b/ndk-wallet/src/wallets/nwc/index.ts
@@ -56,7 +56,7 @@ export class NDKNWCWallet extends EventEmitter<NDKWalletEvents> implements NDKWa
      */
     async initWithPairingCode(uri: string) {
         const u = new URL(uri);
-        const pubkey = u.host ?? u.pathname;
+        const pubkey = u.host || u.pathname;
         const relayUrls = u.searchParams.getAll("relay");
         const secret = u.searchParams.get("secret");
 


### PR DESCRIPTION
### Description

The `URL` constructor in the browser parses URLs differently than in node.

With the current implementation of NWC in NDK, I don't see a way to get NWC working in the browser using `NdkNWC.fromURI`. I always get `pubkey not set` because NDK uses

```js
pubkey: u.host ?? u.pathname
```

instead of

```js
pubkey: u.host || u.pathname
```

here:

https://github.com/nostr-dev-kit/ndk/blob/6b3ea8b298680bee654ba87107da09bc5a63cb54/ndk/src/nwc/index.ts#L94-L110

For example, if I use `nostr+walletconnect://`:

node: `u.host` :white_check_mark: | `u.pathname` :x: 

```
$ node
Welcome to Node.js v20.18.0.
Type ".help" for more information.
> new URL("nostr+walletconnect://2eb69717e2dac6c052ba7ab8cb164c5886c1ddaf3161b53e72d31cd8695a7715?relay=wss%3A%2F%2Frelay.primal.net&secret=2683ed09282e1b0d1545dd39957add77ce489ca37fd5fbb8f7b2e6b039272b88")
URL {
  href: 'nostr+walletconnect://2eb69717e2dac6c052ba7ab8cb164c5886c1ddaf3161b53e72d31cd8695a7715?relay=wss%3A%2F%2Frelay.primal.net&secret=2683ed09282e1b0d1545dd39957add77ce489ca37fd5fbb8f7b2e6b039272b88',
  origin: 'null',
  protocol: 'nostr+walletconnect:',
  username: '',
  password: '',
  host: '2eb69717e2dac6c052ba7ab8cb164c5886c1ddaf3161b53e72d31cd8695a7715',
  hostname: '2eb69717e2dac6c052ba7ab8cb164c5886c1ddaf3161b53e72d31cd8695a7715',
  port: '',
  pathname: '',
  search: '?relay=wss%3A%2F%2Frelay.primal.net&secret=2683ed09282e1b0d1545dd39957add77ce489ca37fd5fbb8f7b2e6b039272b88',
  searchParams: URLSearchParams {
    'relay' => 'wss://relay.primal.net',
    'secret' => '2683ed09282e1b0d1545dd39957add77ce489ca37fd5fbb8f7b2e6b039272b88' },
  hash: ''
}
```

browser: `u.host` :x: | `u.pathname` :x: (includes `//`)

![2024-11-29-041912_1376x256_scrot](https://github.com/user-attachments/assets/d6648851-ab16-4f6a-8cf7-244e73054189)

If I use `nostr+walletconnect:`:

node: `u.host` :x: | `u.pathname` :white_check_mark:

```
> new URL("nostr+walletconnect:2eb69717e2dac6c052ba7ab8cb164c5886c1ddaf3161b53e72d31cd8695a7715?relay=wss%3A%2F%2Frelay.primal.net&secret=2683ed09282e1b0d1545dd39957add77ce489ca37fd5fbb8f7b2e6b039272b88")
URL {
  href: 'nostr+walletconnect:2eb69717e2dac6c052ba7ab8cb164c5886c1ddaf3161b53e72d31cd8695a7715?relay=wss%3A%2F%2Frelay.primal.net&secret=2683ed09282e1b0d1545dd39957add77ce489ca37fd5fbb8f7b2e6b039272b88',
  origin: 'null',
  protocol: 'nostr+walletconnect:',
  username: '',
  password: '',
  host: '',
  hostname: '',
  port: '',
  pathname: '2eb69717e2dac6c052ba7ab8cb164c5886c1ddaf3161b53e72d31cd8695a7715',
  search: '?relay=wss%3A%2F%2Frelay.primal.net&secret=2683ed09282e1b0d1545dd39957add77ce489ca37fd5fbb8f7b2e6b039272b88',
  searchParams: URLSearchParams {
    'relay' => 'wss://relay.primal.net',
    'secret' => '2683ed09282e1b0d1545dd39957add77ce489ca37fd5fbb8f7b2e6b039272b88' },
  hash: ''
}
```

browser: `u.host` :x: | `u.pathname` :white_check_mark: 

![2024-11-29-042030_1362x257_scrot](https://github.com/user-attachments/assets/6fcd7b39-d804-4e5b-8853-db8466d3539f)

Since in both cases, the browser will set `u.host` to the empty string, the pubkey is never set in the browser. Using `||` instead of `??` fixes that at least for the `nostr+walletconnect:` case.

### Additional context

Alby replaces the protocol with `http://` to get consistent URL parsing behavior in node and browser for any NWC prefix, see [here](https://github.com/getAlby/js-sdk/blob/ee07a4c8d9c294eacf4198b48b3e7ed61fb9c5eb/src/NWCClient.ts#L224-L251). I recommend to do the same but I didn't want to change this code more than necessary to get it working using at least one prefix before feedback.

### Environment

NDK version: v2.10.5
node version: 20.18.0
Brave version: 1.62.165 Chromium: 121.0.6167.184 (Official Build) (64-bit)
Firefox version: 132.0.2 (64-bit)