### PR TITLE
Fix 'reference' URL in docs/.vitepress/config.mts

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -11,7 +11,7 @@ export default withMermaid(defineConfig({
     // https://vitepress.dev/reference/default-theme-config
     nav: [
       { text: 'Home', link: '/' },
-      { text: 'API Reference', link: '/api/', target: '_blank' },
+      { text: 'API Reference', link: 'https://github.com/nostr-dev-kit/ndk/blob/master/REFERENCES.md', target: '_blank' },
       { text: 'Wiki', link: 'https://wikifreedia.xyz/?c=NDK', target: '_blank' },
     ],
 


### PR DESCRIPTION
~~Looks like the nav bar "Reference" link was old?~~

Actually wait. "API Reference" and _References_ are different.  
Maybe there is no API reference anymore? 