### PR TITLE
Fix bad computation wallet state

### DIFF
--- a/ndk-wallet/src/wallets/cashu/event-handlers/token.ts
+++ b/ndk-wallet/src/wallets/cashu/event-handlers/token.ts
@@ -6,7 +6,13 @@ export async function handleToken(this: NDKCashuWallet, event: NDKEvent) {
     if (this.state.tokens.has(event.id)) return;
 
     const token = await NDKCashuToken.from(event);
-    if (!token) return;
+    if (!token) {
+        return;
+    }
+
+    for (const deletedTokenId of token.deletedTokens) {
+        this.state.removeTokenId(deletedTokenId);
+    }
 
     this.state.addToken(token);
 }

--- a/ndk-wallet/src/wallets/cashu/wallet/index.ts
+++ b/ndk-wallet/src/wallets/cashu/wallet/index.ts
@@ -221,14 +221,11 @@ export class NDKCashuWallet extends EventEmitter<NDKWalletEvents & {
         // if we have an event add it to the filter
         if (this.event) {
             filters[0] = { ...filters[0], ...this.event.filter(), since: opts?.since }; // add to CashuToken filter
-            filters[1] = { ...filters[1], ...this.event.filter(), since: opts?.since }; // add to WalletChange filter
-            filters[2] = { ...filters[2], ...this.event.filter(), since: opts?.since }; // add to CashuQuote filter
+            filters[1] = { ...filters[1], ...this.event.filter(), since: opts?.since }; // add to CashuQuote filter
         }
 
         opts ??= {};
         opts.subId ??= "cashu-wallet-state";
-
-        console.log('Wallet filter', JSON.stringify(filters));
 
         this.sub = this.ndk.subscribe(filters, opts, this.relaySet, false);
         
@@ -554,7 +551,8 @@ export class NDKCashuWallet extends EventEmitter<NDKWalletEvents & {
         this.event.tags = [["d", this.walletId], ["deleted"]];
         if (publish) this.event.publishReplaceable();
 
-        return this.event.delete(reason, publish);
+        const deleteEvent = await this.event.delete(reason, publish);
+        return deleteEvent;
     }
 
 

--- a/ndk-wallet/src/wallets/cashu/wallet/state/token.ts
+++ b/ndk-wallet/src/wallets/cashu/wallet/state/token.ts
@@ -20,14 +20,12 @@ export function addToken(
     // go through the proofs this token is claiming
     let added = 0;
     let invalid = 0;
-    let newAmount = 0;
     for (const proof of token.proofs) {
         const val = maybeAssociateProofWithToken(this, proof, token, state);
         if (val === false) {
             invalid++;
         } else {
             added++;
-            newAmount += proof.amount;
         }
     }
 }


### PR DESCRIPTION
This PR fixes issues with state calculation of NIP-60 wallets.

* The filter to receive event deletions was wrong! No deletions were being received since event deletions don't tag the wallet
* Adds the new `del` to the token for better state transition
* proofs were not being assigned their token properly