### PR TITLE
Update nip57.ts

### DIFF
--- a/ndk/src/zapper/nip57.ts
+++ b/ndk/src/zapper/nip57.ts
@@ -43,11 +43,6 @@ export async function generateZapRequest(
         event.tags = event.tags.concat(tags);
     }
 
-    // remove e-tags if we have an a-tag
-    if (event.hasTag("a")) {
-        event.tags = event.tags.filter((tag) => tag[0] !== "e");
-    }
-
     // make sure we only have one `p` tag
     event.tags = event.tags.filter((tag) => tag[0] !== "p");
     event.tags.push(["p", pubkey]);


### PR DESCRIPTION
There is no requirement to only have `a` or `e` in zaps. Some zaps like zap.streams' tag both the stream (`a`) and a goal (`e`).