### PR TITLE
fix: export functions from gift-wrapping.js

### DIFF
--- a/ndk-core/src/index.ts
+++ b/ndk-core/src/index.ts
@@ -37,6 +37,8 @@ export * from "./events/kinds/wiki.js";
 
 export * from "./events/wrap.js";
 
+export * from "./events/gift-wrapping.js";
+
 export * from "./thread/index.js";
 
 export * from "./events/kinds/simple-group/index.js";


### PR DESCRIPTION
giftWrap() and giftUnwrap() functions should be available for use by implementations. 