### PR TITLE
Fixes #313

### DIFF
--- a/ndk-cache-dexie/src/lru-cache.ts
+++ b/ndk-cache-dexie/src/lru-cache.ts
@@ -13,7 +13,7 @@ export interface CacheOptions<T> {
 }
 
 export class CacheHandler<T> {
-    private cache: LRUCache<string, T> = new LRUCache({ maxSize: 0 });
+    private cache?: LRUCache<string, T>;
     private dirtyKeys: Set<string> = new Set();
     private options: CacheOptions<T>;
     private debug: debug.IDebugger;


### PR DESCRIPTION
This fixes #313 

The [LRUCache constructor](https://github.com/rob893/typescript-lru-cache/blob/85219438964f12165eb2cf8531bb6bfacf11b657/src/LRUCache.ts#L149) does not accept a maxSize <= 0.

I was not able to figure out if there was further impact from not having the private cache initialized before the constructor of CacheHandler.