### PR TITLE
fix: `profileFromEvent` parser replaces `created_at` 

### DIFF
--- a/ndk-core/src/user/profile.ts
+++ b/ndk-core/src/user/profile.ts
@@ -34,7 +34,6 @@ export function profileFromEvent(event: NDKEvent): NDKUserProfile {
         throw new Error(`Failed to parse profile event: ${error}`);
     }
 
-    profile.created_at = event.created_at;
     profile.profileEvent = JSON.stringify(event.rawEvent());
 
     for (const key of Object.keys(payload)) {
@@ -76,6 +75,8 @@ export function profileFromEvent(event: NDKEvent): NDKUserProfile {
                 break;
         }
     }
+
+    profile.created_at = event.created_at;
 
     return profile;
 }


### PR DESCRIPTION
# Problem

Noticed when using `serializeProfile` and `profileFromEvent`  - received stale `created_at` in payload which  stopped cache update on publish. 

https://github.com/nostr-dev-kit/ndk/blob/b42ef661183b1a1b9b968b0a107fa991b07de3bc/ndk-core/src/user/profile.ts#L37

The workaround to the issue is to carefully construct the new profile update event, but with this update, that will no longer be necessary.

# Change Made
Changed the order when setting `created_at` in `profileFromEvent` function. 

# Result

The update will make sure that the event's `created_at` always takes priority.

The event's `created_at` will now overwrite the payload's `created_at` (if present). 


