### PR TITLE
fix: gift unwrap validation

### DIFF
--- a/ndk-core/src/events/gift-wrapping.ts
+++ b/ndk-core/src/events/gift-wrapping.ts
@@ -68,7 +68,7 @@ export async function giftUnwrap(
         const rumorSender = new NDKUser({ pubkey: seal.pubkey });
         const rumor = JSON.parse(await signer.decrypt(rumorSender, seal.content, scheme));
         if (!rumor) throw new Error("Failed to decrypt seal");
-        if (rumor.pubkey !== _sender.pubkey) throw new Error("Invalid GiftWrap, sender validation failed!");
+        if (rumor.pubkey !== seal.pubkey) throw new Error("Invalid GiftWrap, sender validation failed!");
 
         return new NDKEvent(event.ndk, rumor as NostrEvent);
     } catch (_e) {


### PR DESCRIPTION
# Problem
Per spec the gift wrap event has random pubkey, unrelated to sender. 
https://github.com/nostr-protocol/nips/blob/master/17.md
```json
{
  ...
  "pubkey": randomPublicKey,
  "kind": 1059, // gift wrap
  "content": nip44Encrypt(
    {
      ...
      "pubkey": senderPublicKey,
  ...
}
```

In `giftUnwrap` during the validation the sender is compared with the rumor's pubkey, which according to spec should never be equal.

https://github.com/nostr-dev-kit/ndk/blob/b42ef661183b1a1b9b968b0a107fa991b07de3bc/ndk-core/src/events/gift-wrapping.ts#L71

# Change Made
Changed the validation comparison to compare seal and rumor pubkeys. 