### PR TITLE
Allow manual reconnect even when reconnectTimeout is set

### DIFF
--- a/ndk-core/src/relay/connectivity.ts
+++ b/ndk-core/src/relay/connectivity.ts
@@ -66,8 +66,7 @@ export class NDKRelayConnectivity {
      */
     public async connect(timeoutMs?: number, reconnect = true): Promise<void> {
         if (
-            (this._status !== NDKRelayStatus.RECONNECTING && this._status !== NDKRelayStatus.DISCONNECTED) ||
-            this.reconnectTimeout
+            (this._status !== NDKRelayStatus.RECONNECTING && this._status !== NDKRelayStatus.DISCONNECTED)
         ) {
             this.debug(
                 "Relay requested to be connected but was in state %s or it had a reconnect timeout",


### PR DESCRIPTION
This PR removes the check for reconnectTimeout when attempting to reconnect a relay, allowing consumers to force a reconnection manually without waiting for the scheduled timeout to elapse.

In the current implementation, if a reconnect is already scheduled (reconnectTimeout is set), calling connect() is ignored. This prevents manual reconnection attempts in cases where immediate recovery is required

The conditional guard was simplified to only check the relay status. This enables consumers to override and reconnect as needed, even if a timeout is pending. Any previously scheduled timeout is still cleared before proceeding with the new connection attempt.