### PR TITLE
perf: optimize SQLite WASM cache performance

### DIFF
--- a/core/src/subscription/index.ts
+++ b/core/src/subscription/index.ts
@@ -898,7 +898,7 @@ export class NDKSubscription extends EventEmitter<{
                     }
                 }
 
-                if (this.ndk.cacheAdapter && !this.opts.dontSaveToCache && !kindIsEphemeral(ndkEvent.kind as NDKKind)) {
+                if (this.ndk.cacheAdapter && !this.opts.dontSaveToCache && !kindIsEphemeral(ndkEvent.kind as NDKKind) && !fromCache) {
                     this.ndk.cacheAdapter.setEvent(ndkEvent, this.filters, relay);
                 }
             }


### PR DESCRIPTION
## Summary

Fixes critical performance bottlenecks in the SQLite WASM cache adapter:

- **Fix cache write-back bug**: Events read from cache were being written back to cache, causing 100% duplicate writes on app boot
- **Add JSON transfer for small results**: Results with <100 events now use direct JSON transfer instead of binary encoding, eliminating encoding/decoding overhead for most queries
- **Add O(1) duplicate checking**: In-memory Set tracks cached event IDs for instant duplicate detection without worker communication
- **Add SQL LIMIT support**: Parameterized LIMIT clause reduces result sizes at the database level

## Performance Impact

| Metric | Before | After |
|--------|--------|-------|
| LCP | High (encoding alone: 689ms for 1655 events) | **675ms total** |
| Duplicate writes on boot | 100% | **0%** |
| Small query overhead | Binary encode + decode | **Direct JSON transfer** |

## Changes

- `core/src/subscription/index.ts`: Add `!fromCache` check to prevent cache write-back
- `cache-sqlite-wasm/src/index.ts`: Add in-memory Set for O(1) duplicate checking  
- `cache-sqlite-wasm/src/worker.ts`: Add JSON transfer for small results (<100 events)
- `cache-sqlite-wasm/src/functions/query.ts`: Add parameterized LIMIT clause, track cached event IDs

## Test plan

- [x] Verified LCP improvement with Chrome DevTools performance profiling
- [x] Confirmed no decode errors with JSON transfer
- [x] Validated duplicate write prevention via console logging