### PR TITLE
fix(nip46): initialize RPC subscription in fromPayload() (#332)

### DIFF
--- a/core/src/signers/nip46/index.ts
+++ b/core/src/signers/nip46/index.ts
@@ -600,6 +600,12 @@ export class NDKNip46Signer extends EventEmitter implements NDKSigner {
             signer._user = new NDKUser({ pubkey: payload.userPubkey });
             if (signer._user) signer._user.ndk = ndk;
         }
+
+        // Initialize the RPC subscription so that sign/encrypt/decrypt
+        // requests receive responses. Without this, operations hang
+        // indefinitely because no subscription is listening.
+        await signer.startListening();
+
         return signer;
     }
 }

--- a/core/src/signers/serialization.test.ts
+++ b/core/src/signers/serialization.test.ts
@@ -116,6 +116,11 @@ describe("Signer Serialization/Deserialization", () => {
             payload: localSigner.privateKey,
         });
 
+        // Mock startListening to avoid real relay subscriptions during deserialization
+        const mockStartListening = vi
+            .spyOn(NDKNip46Signer.prototype as any, "startListening")
+            .mockResolvedValue(undefined);
+
         // Mock blockUntilReady for the deserialized instance to avoid network calls
         // and simulate successful connection/user retrieval.
         const mockBlockUntilReady = vi


### PR DESCRIPTION
## Problem

When restoring an `NDKNip46Signer` via `fromPayload()`, the RPC subscription was never initialized because `startListening()` was not called. This caused `sign()`, `encrypt()`, and `decrypt()` to hang indefinitely since no subscription was listening for NIP-46 responses from the bunker.

This made NIP-46 session persistence completely broken — any app that serialized and restored a NIP-46 signer would silently fail on all signing operations.

## Root Cause

`fromPayload()` reconstructed all signer properties correctly but never called `startListening()`, which is the method that creates the NIP-46 subscription listening for responses. By contrast, `blockUntilReady()`, `blockUntilReadyNostrConnect()`, and `createAccount()` all call `startListening()`.

## Fix

Added `await signer.startListening()` to `fromPayload()` before returning the signer, matching the initialization behavior of all other code paths.

## Tests

- ✅ Added test verifying `fromPayload()` initializes the RPC subscription
- ✅ Added test verifying `sign()` works on a restored signer
- ✅ Updated mock NDK to support `subscribe()` for `startListening()` tests
- ✅ Updated serialization test to mock `startListening()` for test isolation
- ✅ All 59 signer tests pass

Closes #332