### PR TITLE
fix(cache-nostr): include dist files in npm package

### DIFF
--- a/cache-nostr/package.json
+++ b/cache-nostr/package.json
@@ -4,6 +4,9 @@
   "description": "NDK cache adapter that uses a local nostr relay.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
+  "files": [
+    "dist"
+  ],
   "exports": {
     "import": {
       "types": "./dist/index.d.mts",

--- a/cache-nostr/package.json
+++ b/cache-nostr/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "dev": "bun run build --watch",
     "build": "tsup src/index.ts --format cjs,esm --dts",
+    "prepublishOnly": "bun run build",
     "clean": "rm -rf dist",
     "lint": "prettier --check . && eslint .",
     "format": "prettier --write ."


### PR DESCRIPTION
Add a "files" allowlist to cache-nostr/package.json so published npm tarballs include the dist artifacts referenced by main/module/exports.

Why:
- @nostr-dev-kit/cache-nostr@0.1.66 from npm fails to import/require because dist/index.js and dist/index.mjs are missing.

Validation:
- npm pack --dry-run includes dist/index.js and dist/index.mjs
- isolated import/require checks pass with local tarball
- manual NDK + cache-nostr functional app test passes (publish + 2 fetches)

Fixes #256