### PR TITLE
fix(nip46): accept secret-echo connect response and send remote-signer-pubkey as first param per NIP-46

### DIFF
--- a/core/src/signers/nip46/index.test.ts
+++ b/core/src/signers/nip46/index.test.ts
@@ -180,6 +180,41 @@ describe("NDKNip46Signer", () => {
             expect(capturedParams?.[1]).toBe("shh");
         });
 
+        it("blockUntilReady sends bunkerPubkey (not userPubkey) as first connect param when the URI carries ?pubkey=", async () => {
+            // Per NIP-46, connect.params[0] is the remote-signer-pubkey. For a
+            // multi-user signer URI like
+            //   bunker://<bunkerPubkey>?pubkey=<userPubkey>&relay=...&secret=...
+            // NDK parses `?pubkey=` into userPubkey — but that value is the
+            // user identity, NOT the connect target. params[0] must still be
+            // bunkerPubkey, or signers that validate it against their own
+            // signer pubkey reject the otherwise-valid token. userPubkey is
+            // resolved separately via get_public_key after the handshake.
+            const token =
+                "bunker://bunkerpubkey?pubkey=userpubkey&relay=wss://relay.example.com&secret=shh";
+            const signer = NDKNip46Signer.bunker(ndk, token, localSigner);
+
+            const mockRpc = createMockRpc();
+            (signer as any).rpc = mockRpc as NDKNostrRpc;
+            (signer as any).startListening = vi.fn();
+            (signer as any).userPubkey = "userpubkey"; // ← distinct from bunkerPubkey
+            (signer as any).bunkerPubkey = "bunkerpubkey";
+            (signer as any).secret = "shh";
+
+            (signer as any).getPublicKey = vi.fn().mockResolvedValue("userpubkey");
+
+            let capturedParams: any[] | undefined;
+            (mockRpc.sendRequest as any).mockImplementation(
+                (_bunkerPubkey: string, _method: string, params: any[], _kind: number, cb: Function) => {
+                    capturedParams = params;
+                    cb({ result: "ack" });
+                },
+            );
+
+            await signer.blockUntilReady();
+            expect(capturedParams?.[0]).toBe("bunkerpubkey"); // NOT "userpubkey"
+            expect(capturedParams?.[1]).toBe("shh");
+        });
+
         it("blockUntilReady rejects with a real Error (not undefined) for unexpected connect responses", async () => {
             // Pre-fix, NDK rejected with `response.error` which is `undefined`
             // when the bunker returns a non-error non-ack result. Downstream

--- a/core/src/signers/nip46/index.test.ts
+++ b/core/src/signers/nip46/index.test.ts
@@ -120,6 +120,90 @@ describe("NDKNip46Signer", () => {
             expect(user.pubkey).toBe("userpubkey");
         });
 
+        it("blockUntilReady resolves user on URI secret echoed back (NIP-46 spec)", async () => {
+            // Per NIP-46, a successful `connect` response result is either
+            // "ack" OR the URI secret echoed back. Spec-compliant signers
+            // like Clave (https://github.com/DocNR/clave) and any signer
+            // matching nostr-tools' BunkerSigner.fromURI semantics return
+            // the secret-echo form.
+            const token = "bunker://bunkerpubkey?pubkey=userpubkey&relay=wss://relay.example.com&secret=shh";
+            const signer = NDKNip46Signer.bunker(ndk, token, localSigner);
+
+            const mockRpc = createMockRpc();
+            (signer as any).rpc = mockRpc as NDKNostrRpc;
+            (signer as any).startListening = vi.fn();
+            (signer as any).userPubkey = "userpubkey";
+            (signer as any).bunkerPubkey = "bunkerpubkey";
+            (signer as any).secret = "shh";
+
+            (signer as any).getPublicKey = vi.fn().mockResolvedValue("userpubkey");
+
+            // Bunker returns the URI secret echoed back instead of "ack".
+            (mockRpc.sendRequest as any).mockImplementation(
+                (_bunkerPubkey: string, _method: string, _params: any[], _kind: number, cb: Function) => {
+                    cb({ result: "shh" });
+                },
+            );
+
+            const user = await signer.blockUntilReady();
+            expect(user).toBeInstanceOf(NDKUser);
+            expect(user.pubkey).toBe("userpubkey");
+        });
+
+        it("blockUntilReady sends bunkerPubkey as first connect param when no userPubkey", async () => {
+            // Per NIP-46, the first parameter to `connect` is the
+            // remote-signer-pubkey, not the user-pubkey. For bunker:// URIs
+            // without `?pubkey=` (the typical single-user signer case),
+            // userPubkey is null — fall through to bunkerPubkey.
+            const token = "bunker://bunkerpubkey?relay=wss://relay.example.com&secret=shh";
+            const signer = NDKNip46Signer.bunker(ndk, token, localSigner);
+
+            const mockRpc = createMockRpc();
+            (signer as any).rpc = mockRpc as NDKNostrRpc;
+            (signer as any).startListening = vi.fn();
+            (signer as any).userPubkey = null; // ← typical Clave-style URI: no ?pubkey=
+            (signer as any).bunkerPubkey = "bunkerpubkey";
+            (signer as any).secret = "shh";
+
+            (signer as any).getPublicKey = vi.fn().mockResolvedValue("userpubkey");
+
+            let capturedParams: any[] | undefined;
+            (mockRpc.sendRequest as any).mockImplementation(
+                (_bunkerPubkey: string, _method: string, params: any[], _kind: number, cb: Function) => {
+                    capturedParams = params;
+                    cb({ result: "ack" });
+                },
+            );
+
+            await signer.blockUntilReady();
+            expect(capturedParams?.[0]).toBe("bunkerpubkey");
+            expect(capturedParams?.[1]).toBe("shh");
+        });
+
+        it("blockUntilReady rejects with a real Error (not undefined) for unexpected connect responses", async () => {
+            // Pre-fix, NDK rejected with `response.error` which is `undefined`
+            // when the bunker returns a non-error non-ack result. Downstream
+            // catch handlers (e.g. `e.message`) would then throw a confusing
+            // TypeError on `undefined`. Now we always reject with an Error.
+            const token = "bunker://bunkerpubkey?pubkey=userpubkey&relay=wss://relay.example.com";
+            const signer = NDKNip46Signer.bunker(ndk, token, localSigner);
+
+            const mockRpc = createMockRpc();
+            (signer as any).rpc = mockRpc as NDKNostrRpc;
+            (signer as any).startListening = vi.fn();
+            (signer as any).userPubkey = "userpubkey";
+            (signer as any).bunkerPubkey = "bunkerpubkey";
+            (signer as any).secret = null; // no secret set, so secret-echo path can't match
+
+            (mockRpc.sendRequest as any).mockImplementation(
+                (_bunkerPubkey: string, _method: string, _params: any[], _kind: number, cb: Function) => {
+                    cb({ result: "something_unexpected" });
+                },
+            );
+
+            await expect(signer.blockUntilReady()).rejects.toThrow(/unexpected NIP-46 connect response/);
+        });
+
         it("signs events via RPC", async () => {
             const token = "bunker://bunkerpubkey?pubkey=userpubkey&relay=wss://relay.example.com";
             const signer = NDKNip46Signer.bunker(ndk, token, localSigner);

--- a/core/src/signers/nip46/index.ts
+++ b/core/src/signers/nip46/index.ts
@@ -344,14 +344,25 @@ export class NDKNip46Signer extends EventEmitter implements NDKSigner {
         });
 
         const promise = new Promise<NDKUser>((resolve, reject) => {
-            const connectParams = [this.userPubkey ?? ""];
+            // Per NIP-46, the first parameter to `connect` is the
+            // remote-signer-pubkey, not the user-pubkey. For bunker:// URIs
+            // without `?pubkey=` (the typical single-user signer case),
+            // userPubkey is null — fall through to bunkerPubkey, which is
+            // the URI hostname and is by definition the remote-signer-pubkey.
+            const connectParams = [this.userPubkey || this.bunkerPubkey || ""];
 
             if (this.secret) connectParams.push(this.secret);
 
             if (!this.bunkerPubkey) throw new Error("Bunker pubkey not set");
 
             this.rpc.sendRequest(this.bunkerPubkey, "connect", connectParams, 24133, (response: NDKRpcResponse) => {
-                if (response.result === "ack") {
+                // Per NIP-46, a successful `connect` response result is
+                // either `"ack"` OR the URI secret echoed back. The latter
+                // is what spec-compliant signers like Clave
+                // (https://github.com/DocNR/clave) and any signer matching
+                // nostr-tools' BunkerSigner.fromURI semantics return.
+                const ok = response.result === "ack" || (this.secret != null && response.result === this.secret);
+                if (ok) {
                     this.getPublicKey().then(async (pubkey) => {
                         this.userPubkey = pubkey;
                         this._user = this.ndk.getUser({ pubkey });
@@ -359,7 +370,7 @@ export class NDKNip46Signer extends EventEmitter implements NDKSigner {
                         resolve(this._user);
                     }).catch(reject);
                 } else {
-                    reject(response.error);
+                    reject(new Error(response.error || `unexpected NIP-46 connect response: ${response.result}`));
                 }
             });
         });

--- a/core/src/signers/nip46/index.ts
+++ b/core/src/signers/nip46/index.ts
@@ -345,11 +345,19 @@ export class NDKNip46Signer extends EventEmitter implements NDKSigner {
 
         const promise = new Promise<NDKUser>((resolve, reject) => {
             // Per NIP-46, the first parameter to `connect` is the
-            // remote-signer-pubkey, not the user-pubkey. For bunker:// URIs
-            // without `?pubkey=` (the typical single-user signer case),
-            // userPubkey is null — fall through to bunkerPubkey, which is
-            // the URI hostname and is by definition the remote-signer-pubkey.
-            const connectParams = [this.userPubkey || this.bunkerPubkey || ""];
+            // remote-signer-pubkey, not the user-pubkey:
+            //   connect: [<remote-signer-pubkey>, <optional_secret>, ...]
+            // bunkerPubkey is the URI host and is by definition the
+            // remote-signer-pubkey. Even when the URI carries
+            // `?pubkey=<user-pubkey>` (multi-user signers), that value is the
+            // user identity, not the connect target — it is resolved
+            // separately via get_public_key after the handshake. Sending
+            // userPubkey here breaks signers that validate connect.params[0]
+            // against their own signer pubkey. (nostr-tools' BunkerSigner
+            // sends `this.bp.pubkey` — the bunker pubkey — likewise.)
+            // bunkerPubkey is guaranteed set by the guard earlier in
+            // blockUntilReady; `?? ""` only satisfies the type checker.
+            const connectParams = [this.bunkerPubkey ?? ""];
 
             if (this.secret) connectParams.push(this.secret);
 


### PR DESCRIPTION
## Summary

`NDKNip46Signer.blockUntilReady` has two NIP-46 spec violations on the `bunker://` path that prevent connecting to spec-compliant signers (e.g. [Clave](https://github.com/DocNR/clave), nsec.app's bunker, anything matching `nostr-tools` `BunkerSigner.fromURI` semantics). Both bugs are present in every released NDK from 2.12.x through 3.0.3.

Per the [NIP-46 spec](https://github.com/nostr-protocol/nips/blob/master/46.md):

```
connect: [<remote-signer-pubkey>, <optional_secret>, <optional_requested_perms>]
result: "ack" OR <required-secret-value>
```

### Bug 1 — first connect param is the user-pubkey instead of the remote-signer-pubkey

[Line 347](core/src/signers/nip46/index.ts#L347) sends `[this.userPubkey ?? ""]`. For `bunker://` URIs without `?pubkey=` (the typical single-user signer case), `userPubkey` is null → an empty string lands as the first param. Per spec the first param is the remote-signer-pubkey, which for a `bunker://` URI is the URI hostname (= `bunkerPubkey`).

Fixed by falling through to `bunkerPubkey` when `userPubkey` is null.

### Bug 2 — only `"ack"` is accepted as a valid connect response

[Line 354](core/src/signers/nip46/index.ts#L354) only accepts `response.result === "ack"`. Per spec, `"ack"` OR the URI secret echoed back are both valid. Spec-compliant signers like [Clave](https://github.com/DocNR/clave/blob/main/Clave/Shared/LightSigner.swift#L564-L568) and any signer matching `nostr-tools` `BunkerSigner.fromURI` semantics return the secret-echo form. NDK rejects with `response.error` which is `undefined` (no error in the response) — leaving downstream catch handlers to throw `TypeError: Cannot read properties of undefined (reading 'message')`.

Fixed by accepting `response.result === "ack" || response.result === this.secret`.

Drive-by: rejection is now wrapped in a real `Error` so downstream handlers get a useful message instead of `undefined`.

### Note: `blockUntilReadyNostrConnect` already does this right

[Line 287](core/src/signers/nip46/index.ts#L287) of the `nostrconnect://` flow already matches `response.result === this.nostrConnectSecret`. This PR aligns the `bunker://` path with that and with the spec.

### Real-world failure

[stacker.news](https://github.com/stackernews/stacker.news)'s NIP-46 bunker login hangs indefinitely when paired with a Clave bunker URI for exactly these reasons. Companion PR ([stackernews/stacker.news#2947](https://github.com/stackernews/stacker.news/pull/2947)) extends their existing `NDKNip46SignerURLPatch` workaround with the same fix; once this PR ships, that workaround can be deleted on next NDK bump.

## Tests

3 new tests in `core/src/signers/nip46/index.test.ts` (following the existing mock pattern):

- `blockUntilReady resolves user on URI secret echoed back (NIP-46 spec)` — covers Bug 2
- `blockUntilReady sends bunkerPubkey as first connect param when no userPubkey` — covers Bug 1 (URI without `?pubkey=`)
- `blockUntilReady sends bunkerPubkey (not userPubkey) as first connect param when the URI carries ?pubkey=` — covers Bug 1 for multi-user signer URIs (added after review feedback — the earlier fix still sent `userPubkey` as `params[0]` whenever the URI carried `?pubkey=`)
- `blockUntilReady rejects with a real Error (not undefined) for unexpected connect responses` — covers the drive-by

Manually verified the fix against:

- A Clave-emulating mock bunker (returns secret echo) on a local `nak serve` relay → resolves
- A real Clave bunker URI from an iOS TestFlight build on `relay.powr.build` → resolves in ~2s

## Test plan

- [ ] **New unit tests not run locally.** NDK is a `bun` workspace; I don't have `bun` available, and `npm install` inside `core/` doesn't reproduce the workspace layout (`vitest` isn't hoisted into `core/node_modules`). The 4 new tests are written to the exact pattern of the existing `blockUntilReady resolves user on ack` test — same `createMockRpc()` harness, same `mockImplementation` callback shape. A maintainer running `bun test` is the validation gate here; flagging explicitly rather than claiming a green run I didn't do.
- [x] Fix verified end-to-end against a Clave-emulating mock bunker (returns the secret echo) on a local `nak serve` relay **and** against a real Clave bunker URI from an iOS TestFlight build on `relay.powr.build` (resolves in ~2s). The mock-bunker harness drives the real `NDKNip46Signer` code path, not a reimplementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

