### PR TITLE
fix(nip05): replace console.error with debug logger for fetch failures

### DIFF
--- a/core/src/user/nip05.ts
+++ b/core/src/user/nip05.ts
@@ -1,6 +1,9 @@
+import debug from "debug";
 import type { NDK } from "../ndk";
 import type { Hexpubkey, ProfilePointer } from ".";
 import { NDKUser } from ".";
+
+const d = debug("ndk:nip05");
 
 export const NIP05_REGEX = /^(?:([\w.+-]+)@)?([\w.-]+)$/;
 
@@ -59,7 +62,7 @@ export async function getNip05For(
                 if (ndk?.cacheAdapter?.saveNip05) {
                     ndk?.cacheAdapter.saveNip05(fullname, null);
                 }
-                console.error("Failed to fetch NIP05 for", fullname, _e);
+                d("Failed to fetch NIP05 for %s: %O", fullname, _e);
                 return null;
             }
         },


### PR DESCRIPTION
## Problem

\`src/user/nip05.ts\` fires an unconditional \`console.error\` when a NIP-05 fetch fails:

\`\`\`typescript
} catch (_e) {
  ndk?.cacheAdapter?.saveNip05(fullname, null);
  console.error("Failed to fetch NIP05 for", fullname, _e); // cannot be silenced
  return null;
}
\`\`\`

NIP-05 fetch failures are **expected behavior** — many Nostr users have unreachable or expired NIP-05 domains. Application developers have no way to opt out: the only workaround is monkey-patching \`console.error\`, which risks hiding real errors.

Closes #394

## Fix

Add a \`debug\` instance scoped to \`ndk:nip05\` and replace the \`console.error\`:

\`\`\`typescript
import debug from "debug";
const d = debug("ndk:nip05");

// in the catch block:
d("Failed to fetch NIP05 for %s: %O", fullname, _e);
\`\`\`

**Silent by default.** Opt-in via \`DEBUG=ndk:nip05\`.

## Why this is consistent

Every other NDK module already uses the \`debug\` package for internal logging (relay connectivity, subscriptions, authentication). The \`nip05.ts\` module was the only exception — this PR brings it in line with the rest of the codebase.

## Changes

- 1 new import (\`debug\`)  
- 1 new module-level constant (\`const d = debug("ndk:nip05")\`)  
- 1 line changed in the catch block  

Zero behavior change. The function still returns \`null\` and saves a negative cache entry on failure.