### PR TITLE
Support old browsers without RegExp lookbehind support

### DIFF
--- a/core/src/events/content-tagger.test.ts
+++ b/core/src/events/content-tagger.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { generateContentTags } from "./content-tagger";
+import { generateContentTags, generateHashtags } from "./content-tagger";
 import type { ContentTaggingOptions, NDKEvent, NDKTag } from "./index.js";
 
 describe("await generateContentTags", () => {
@@ -280,5 +280,16 @@ describe("await generateContentTags", () => {
 
             expect(processedTags).toEqual([["p", "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52"]]);
         });
+    });
+});
+
+describe("generateHashtags", () => {
+    it("extracts hashtags with leading whitespace trimmed", () => {
+        expect(generateHashtags("Hello #bitcoin and #nostr")).toEqual(["bitcoin", "nostr"]);
+        expect(generateHashtags("  #bitcoin")).toEqual(["bitcoin"]);
+    });
+
+    it("ignores hashtags embedded in words", () => {
+        expect(generateHashtags("word#ndk")).toEqual([]);
     });
 });

--- a/core/src/events/content-tagger.ts
+++ b/core/src/events/content-tagger.ts
@@ -85,7 +85,7 @@ export function uniqueTag(a: NDKTag, b: NDKTag): NDKTag[] {
     return [a, b];
 }
 
-const hashtagRegex = /(?<=\s|^)(#[^\s!@#$%^&*()=+./,[{\]};:'"?><]+)/g;
+const hashtagRegex = /(?:^|\s)(#[^\s!@#$%^&*()=+./,[{\]};:'"?><]+)/g;
 
 /**
  * Generates a unique list of hashtags as used in the content. If multiple variations
@@ -94,7 +94,7 @@ const hashtagRegex = /(?<=\s|^)(#[^\s!@#$%^&*()=+./,[{\]};:'"?><]+)/g;
  * @returns
  */
 export function generateHashtags(content: string): string[] {
-    const hashtags = content.match(hashtagRegex);
+    const hashtags = content.match(hashtagRegex)?.map((m) => m.trimStart());
     const tagIds = new Set<string>();
     const tag = new Set<string>();
     if (hashtags) {


### PR DESCRIPTION
Replace the hashtag regex lookbehind (?<=\s|^) with (?:^|\s) and trim matches, so generateHashtags works on older iPhones/Safari where lookbehind throws a SyntaxError. Needed for my Nostr client [Brezn](https://github.com/DaBena/Brezn/tree/main/patches) . Behavior is unchanged on modern browsers.