### PR TITLE
fix(core): prevent signature verification from silently disabling due to NaN ratio

### DIFF
--- a/core/src/ndk/index.ts
+++ b/core/src/ndk/index.ts
@@ -498,7 +498,7 @@ export class NDK extends EventEmitter<{
 
         this.initialValidationRatio = opts.initialValidationRatio || 1.0;
         this.lowestValidationRatio = opts.lowestValidationRatio || 0.1;
-        this.validationRatioFn = opts.validationRatioFn || this.defaultValidationRatioFn;
+        this.validationRatioFn = opts.validationRatioFn || this.defaultValidationRatioFn.bind(this);
         this.filterValidationMode = opts.filterValidationMode || "validate";
         this.aiGuardrails = new AIGuardrails(opts.aiGuardrails || false);
         this.futureTimestampGrace = opts.futureTimestampGrace;

--- a/core/src/relay/index.ts
+++ b/core/src/relay/index.ts
@@ -292,7 +292,8 @@ export class NDKRelay extends EventEmitter<{
             return false;
         }
 
-        if (this.targetValidationRatio === undefined) {
+        // Non-finite ratio: verify rather than silently skip
+        if (!Number.isFinite(this.targetValidationRatio)) {
             return true;
         }
 

--- a/core/src/relay/validation-ratio.test.ts
+++ b/core/src/relay/validation-ratio.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { NDK } from "../ndk/index";
 import { NDKRelay } from "./index";
 
@@ -33,5 +33,55 @@ describe("Relay Validation Ratio", () => {
 
         // Should never validate events from trusted relays
         expect(relay.shouldValidateEvent()).toBe(false);
+    });
+});
+
+// Regression: defaultValidationRatioFn was bound to NDKRelay (which lacks
+// initialValidationRatio) instead of NDK, producing NaN at validatedCount>=10.
+describe("defaultValidationRatioFn binding (NaN regression)", () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    test("rebound fn returns finite ratios at every count threshold", () => {
+        const ndk = new NDK({ initialValidationRatio: 1.0, lowestValidationRatio: 0.1 });
+        const relay = new NDKRelay("wss://t.relay", undefined, ndk);
+        const fn = relay.validationRatioFn!; // rebound to relay in its ctor
+
+        for (const c of [0, 9, 10, 50, 100, 1000]) {
+            const r = fn(relay, c, 0);
+            expect(Number.isFinite(r)).toBe(true);
+            expect(r).toBeGreaterThanOrEqual(0.1);
+            expect(r).toBeLessThanOrEqual(1.0);
+        }
+
+        // Exact decay: <10 -> initial; 10 -> 0.91; >=100 -> floor 0.1.
+        expect(fn(relay, 9, 0)).toBe(1.0);
+        expect(fn(relay, 10, 0)).toBeCloseTo(0.91, 5);
+        expect(fn(relay, 100, 0)).toBeCloseTo(0.1, 5);
+    });
+
+    test("30s timer keeps targetValidationRatio finite; verification not stuck off", () => {
+        const ndk = new NDK({ initialValidationRatio: 1.0, lowestValidationRatio: 0.1 });
+        const relay = new NDKRelay("wss://t.relay", undefined, ndk);
+
+        for (let i = 0; i < 100; i++) relay.addValidatedEvent();
+        vi.advanceTimersByTime(30_000);
+
+        expect(Number.isFinite(relay.targetValidationRatio)).toBe(true);
+        // At a finite ratio in [0.1, 1.0), some draws verify. Not permanently false.
+        const anyTrue = Array.from({ length: 1000 }, () => relay.shouldValidateEvent()).some(Boolean);
+        expect(anyTrue).toBe(true);
+    });
+
+    test("non-finite targetValidationRatio fails safe (verifies)", () => {
+        const ndk = new NDK();
+        const relay = new NDKRelay("wss://t.relay", undefined, ndk);
+
+        // Simulate the pre-fix stuck state directly.
+        (relay as any).targetValidationRatio = NaN;
+        expect(relay.shouldValidateEvent()).toBe(true);
+
+        (relay as any).targetValidationRatio = undefined;
+        expect(relay.shouldValidateEvent()).toBe(true);
     });
 });


### PR DESCRIPTION
## Problem

`defaultValidationRatioFn` reads `this.initialValidationRatio` (declared on `NDK`) but was bound to `NDKRelay`, which lacks that field. Once `validatedCount >= 10`, the function returned `NaN`, causing `targetValidationRatio` to become `NaN` on the next 30s timer tick. `shouldValidateEvent()` then returned `false` forever for that relay—verification dropped to 0% instead of the documented 10% floor.

## Fix

1. Bind `defaultValidationRatioFn` to `NDK` at assignment (`ndk/index.ts:501`)
2. Add `!Number.isFinite()` guard in `shouldValidateEvent()` as a fail-safe (`relay/index.ts:296`)

## Tests

Three new regression tests in `validation-ratio.test.ts`:
- Rebound function returns finite ratios across all count thresholds (0, 9, 10, 50, 100, 1000)
- 30s timer maintains finite ratio; verification doesn't get stuck off
- Non-finite ratio fails safe (verifies rather than skips)

All three new tests fail on master and pass with this fix.

## Security Note

This bug silently disables signature verification per-relay after just 10 validated events. Disclosed privately to maintainer prior to submission.