### PR TITLE
core: add sorted event insertion helpers

### DIFF
--- a/.changeset/fresh-events-sort.md
+++ b/.changeset/fresh-events-sort.md
@@ -1,0 +1,5 @@
+---
+"@nostr-dev-kit/ndk": patch
+---
+
+Add helpers for inserting events into ascending and descending timestamp-sorted lists.

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -95,6 +95,7 @@ export { isValidPubkey, isValidEventId, isValidHex64, isValidNip05 } from "./uti
 export * from "./utils/get-users-relay-list.js";
 export * from "./utils/imeta.js";
 export * from "./utils/normalize-url.js";
+export * from "./utils/sorted-events.js";
 export type { NDKZapInvoice } from "./zap/invoice.js";
 export { zapInvoiceFromEvent } from "./zap/invoice.js";
 export * from "./zapper/index.js";

--- a/core/src/utils/index.ts
+++ b/core/src/utils/index.ts
@@ -2,4 +2,5 @@ export * from "../ai-guardrails/index.js";
 export * from "./filter.js";
 export * from "./filter-validation.js";
 export * from "./normalize-url.js";
+export * from "./sorted-events.js";
 export * from "./validation.js";

--- a/core/src/utils/sorted-events.test.ts
+++ b/core/src/utils/sorted-events.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { NDKEvent } from "../events/index.js";
+import { insertEventIntoAscendingList, insertEventIntoDescendingList } from "./sorted-events.js";
+
+function event(id: string, createdAt?: number): NDKEvent {
+    return new NDKEvent(undefined, { id, created_at: createdAt });
+}
+
+describe("sorted event insertion", () => {
+    it("inserts into descending lists without mutating the input", () => {
+        const original = [event("newest", 30), event("middle", 20), event("oldest", 10)];
+        const inserted = insertEventIntoDescendingList(original, event("between", 25));
+
+        expect(inserted.map(({ id }) => id)).toEqual(["newest", "between", "middle", "oldest"]);
+        expect(original.map(({ id }) => id)).toEqual(["newest", "middle", "oldest"]);
+        expect(
+            insertEventIntoDescendingList(inserted, event("first", 40)).map(({ id }) => id),
+        ).toEqual(["first", "newest", "between", "middle", "oldest"]);
+        expect(
+            insertEventIntoDescendingList(inserted, event("last", 5)).map(({ id }) => id),
+        ).toEqual(["newest", "between", "middle", "oldest", "last"]);
+    });
+
+    it("inserts into ascending lists", () => {
+        const original = [event("oldest", 10), event("middle", 20), event("newest", 30)];
+        const inserted = insertEventIntoAscendingList(original, event("between", 25));
+
+        expect(inserted.map(({ id }) => id)).toEqual(["oldest", "middle", "between", "newest"]);
+        expect(
+            insertEventIntoAscendingList(inserted, event("first", 5)).map(({ id }) => id),
+        ).toEqual(["first", "oldest", "middle", "between", "newest"]);
+        expect(
+            insertEventIntoAscendingList(inserted, event("last", 40)).map(({ id }) => id),
+        ).toEqual(["oldest", "middle", "between", "newest", "last"]);
+    });
+
+    it("keeps equal timestamps stable and ignores duplicate event IDs", () => {
+        const list = [event("a", 20), event("b", 20), event("c", 10)];
+        const withEqualTimestamp = insertEventIntoDescendingList(list, event("d", 20));
+
+        expect(withEqualTimestamp.map(({ id }) => id)).toEqual(["a", "b", "d", "c"]);
+
+        const duplicate = insertEventIntoDescendingList(list, event("a", 30));
+        expect(duplicate).toBe(list);
+    });
+
+    it("rejects events without a timestamp", () => {
+        expect(() => insertEventIntoDescendingList([], event("missing"))).toThrow(
+            "Cannot insert an event without created_at",
+        );
+    });
+});

--- a/core/src/utils/sorted-events.ts
+++ b/core/src/utils/sorted-events.ts
@@ -1,0 +1,54 @@
+import type { NDKEvent } from "../events/index.js";
+
+function eventTimestamp(event: NDKEvent): number {
+    if (event.created_at === undefined) {
+        throw new Error("Cannot insert an event without created_at");
+    }
+
+    return event.created_at;
+}
+
+function insertEventIntoSortedList<T extends NDKEvent>(
+    sortedEvents: T[],
+    event: T,
+    descending: boolean,
+): T[] {
+    if (sortedEvents.some((existingEvent) => existingEvent.id === event.id)) return sortedEvents;
+
+    const timestamp = eventTimestamp(event);
+    let low = 0;
+    let high = sortedEvents.length;
+
+    while (low < high) {
+        const middle = Math.floor((low + high) / 2);
+        const middleTimestamp = eventTimestamp(sortedEvents[middle]);
+        const insertBefore = descending ? middleTimestamp < timestamp : middleTimestamp > timestamp;
+
+        if (insertBefore) {
+            high = middle;
+        } else {
+            low = middle + 1;
+        }
+    }
+
+    return [...sortedEvents.slice(0, low), event, ...sortedEvents.slice(low)];
+}
+
+/**
+ * Inserts an event into a list sorted by descending `created_at` without mutating the input list.
+ * Events with the same timestamp keep their existing order. Duplicate event IDs are ignored.
+ */
+export function insertEventIntoDescendingList<T extends NDKEvent>(
+    sortedEvents: T[],
+    event: T,
+): T[] {
+    return insertEventIntoSortedList(sortedEvents, event, true);
+}
+
+/**
+ * Inserts an event into a list sorted by ascending `created_at` without mutating the input list.
+ * Events with the same timestamp keep their existing order. Duplicate event IDs are ignored.
+ */
+export function insertEventIntoAscendingList<T extends NDKEvent>(sortedEvents: T[], event: T): T[] {
+    return insertEventIntoSortedList(sortedEvents, event, false);
+}


### PR DESCRIPTION
## Summary

- add helpers for inserting events into ascending and descending `created_at`-sorted lists
- keep equal timestamps stable and ignore duplicate event IDs
- export the helpers from the core package
- add coverage for insertion order, duplicates, and missing timestamps

## Verification

- `bunx vitest run src/utils/sorted-events.test.ts`
- `bun run compile`
- `bunx prettier --check src/utils/sorted-events.ts src/utils/sorted-events.test.ts src/utils/index.ts src/index.ts`

Closes #56